### PR TITLE
feat: add whoami request diagnostics application

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -28,6 +28,7 @@ graph LR
     NGINX --> |/dvwa/| DVWA[DVWA<br/>Port 8081]
     NGINX --> |/vampi/| VAMPI[VAmPI<br/>Port 5000]
     NGINX --> |/httpbin/| HTTPBIN[httpbin<br/>Port 8080]
+    NGINX --> |/whoami/| WHOAMI[whoami<br/>Port 8082]
 ```
 
 The nginx reverse proxy on the VM:
@@ -47,6 +48,7 @@ The nginx reverse proxy on the VM:
 | `/dvwa/` | DVWA | 8081 | Classic WAF testing with adjustable difficulty |
 | `/vampi/` | VAmPI | 5000 | REST API security testing (OWASP API Top 10) |
 | `/httpbin/` | httpbin | 8080 | HTTP request/response service for API demos |
+| `/whoami/` | whoami | 8082 | Request diagnostics -- shows all headers, client IP, hostname |
 
 ## Modular Component Design
 
@@ -66,3 +68,4 @@ The human operator adds components one at a time. Each component's documentation
 | **DVWA** | Industry standard for WAF testing; adjustable security levels (low/medium/high/impossible); PHP-based for diversity |
 | **VAmPI** | Purpose-built for OWASP API Security Top 10; REST API with known vulnerabilities; lightweight Flask app |
 | **httpbin** | Kenneth Reitz's canonical HTTP testing service; useful for basic API demos and request inspection |
+| **whoami** | Traefik's request echo server; shows full request details as the origin sees them -- essential for verifying F5 XC header injection |

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -277,6 +277,13 @@ write_files:
           ports:
             - "127.0.0.1:8080:80"
 
+        whoami:
+          image: traefik/whoami:latest
+          container_name: whoami
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8082:80"
+
   - path: /etc/nginx/sites-available/origin-server
     content: |
       server {
@@ -285,7 +292,7 @@ write_files:
 
           location /health {
               access_log off;
-              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin"]}';
+              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami"]}';
               add_header Content-Type application/json;
           }
 
@@ -319,6 +326,14 @@ write_files:
               proxy_set_header X-Forwarded-Proto $scheme;
           }
 
+          location /whoami/ {
+              proxy_pass http://127.0.0.1:8082/;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
           location /httpbin/ {
               proxy_pass http://127.0.0.1:8080/;
               proxy_set_header Host $host;
@@ -341,6 +356,7 @@ write_files:
         <li><a href="/dvwa/">DVWA</a> - WAF testing (adjustable difficulty)</li>
         <li><a href="/vampi/">VAmPI</a> - REST API security (OWASP API Top 10)</li>
         <li><a href="/httpbin/">httpbin</a> - HTTP request/response testing</li>
+        <li><a href="/whoami/">whoami</a> - Request diagnostics (headers, IP, hostname)</li>
       </ul>
       <p><a href="/health">Health Check</a></p>
       </body>
@@ -410,6 +426,11 @@ output "httpbin_url" {
   value       = "http://${azurerm_public_ip.origin.ip_address}/httpbin/"
 }
 
+output "whoami_url" {
+  description = "whoami request diagnostics URL"
+  value       = "http://${azurerm_public_ip.origin.ip_address}/whoami/"
+}
+
 output "resource_group" {
   description = "Resource group containing all origin server resources"
   value       = azurerm_resource_group.origin.name
@@ -461,7 +482,7 @@ Expected response:
 {
   "status": "healthy",
   "component": "origin-server",
-  "applications": ["juice-shop", "dvwa", "vampi", "httpbin"]
+  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami"]
 }
 ```
 

--- a/docs/04-applications.mdx
+++ b/docs/04-applications.mdx
@@ -151,6 +151,56 @@ curl -s "http://<PUBLIC_IP>/httpbin/headers" | jq .
 curl -s -o /dev/null -w "%{http_code}" "http://<PUBLIC_IP>/httpbin/status/403"
 ```
 
+## whoami (Request Diagnostics)
+
+| | |
+|---|---|
+| **Path** | `/whoami/` |
+| **Image** | `traefik/whoami:latest` |
+| **Framework** | Go |
+| **Project** | [github.com/traefik/whoami](https://github.com/traefik/whoami) |
+
+whoami is Traefik's lightweight request echo server. It displays every detail of the incoming HTTP request as the origin sees it -- hostname, IP addresses, all headers, method, and URL. This is the single most important diagnostic tool when verifying that F5 XC is injecting the correct headers.
+
+### Key Use Cases
+
+| Use Case | What to Look For |
+|---|---|
+| Verify F5 XC header injection | `X-Forwarded-For`, `True-Client-IP`, `X-Volterra-*` headers |
+| Confirm client IP visibility | `X-Real-IP` vs `RemoteAddr` |
+| Debug WAF false positives | Compare request headers before/after F5 XC |
+| Validate bot defense tagging | `X-Volterra-Bot-Type`, `X-Volterra-Bot-Verified` headers |
+| Check TLS termination | `X-Forwarded-Proto` shows `https` when TLS terminates at F5 XC |
+
+### Example
+
+```bash
+# Basic request -- see what the origin receives
+curl "http://<PUBLIC_IP>/whoami/"
+
+# Simulate request through F5 XC (with injected headers)
+curl "http://<PUBLIC_IP>/whoami/" \
+  -H "X-Forwarded-For: 203.0.113.50" \
+  -H "True-Client-IP: 203.0.113.50" \
+  -H "X-Forwarded-Proto: https"
+```
+
+Example output:
+
+```
+Hostname: 534c5084e169
+IP: 127.0.0.1
+RemoteAddr: 172.17.0.1:55118
+GET / HTTP/1.1
+Host: 20.12.78.159
+User-Agent: curl/8.5.0
+Accept: */*
+True-Client-Ip: 203.0.113.50
+X-Forwarded-For: 203.0.113.50, 10.0.0.1
+X-Forwarded-Proto: https
+X-Real-Ip: 104.219.105.84
+```
+
 ## Application Coverage Matrix
 
 | Demo Use Case | Primary App | Secondary App |
@@ -166,3 +216,5 @@ curl -s -o /dev/null -w "%{http_code}" "http://<PUBLIC_IP>/httpbin/status/403"
 | Client-Side Defense -- DOM XSS | Juice Shop | -- |
 | Client-Side Defense -- Stored XSS | DVWA | Juice Shop |
 | Basic connectivity testing | httpbin | -- |
+| Request diagnostics | whoami | httpbin |
+| Header injection verification | whoami | -- |

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -44,6 +44,9 @@ curl -sf "http://${ORIGIN_IP}/vampi/" -o /dev/null -w "VAmPI: %{http_code}\n"
 
 # httpbin
 curl -sf "http://${ORIGIN_IP}/httpbin/get" -o /dev/null -w "httpbin: %{http_code}\n"
+
+# whoami
+curl -sf "http://${ORIGIN_IP}/whoami/" -o /dev/null -w "whoami: %{http_code}\n"
 ```
 
 All should return `200`.
@@ -64,6 +67,7 @@ juice-shop   Up X minutes   127.0.0.1:3000->3000/tcp
 dvwa         Up X minutes   127.0.0.1:8081->80/tcp
 vampi        Up X minutes   127.0.0.1:5000->5000/tcp
 httpbin      Up X minutes   127.0.0.1:8080->80/tcp
+whoami       Up X minutes   127.0.0.1:8082->80/tcp
 ```
 
 ### nginx Status

--- a/docs/06-integrate.mdx
+++ b/docs/06-integrate.mdx
@@ -48,7 +48,28 @@ Each application is accessible via its path prefix through the load balancer:
 | `https://demo.example.com/dvwa/` | `/dvwa/` | DVWA |
 | `https://demo.example.com/vampi/` | `/vampi/` | VAmPI |
 | `https://demo.example.com/httpbin/` | `/httpbin/` | httpbin |
+| `https://demo.example.com/whoami/` | `/whoami/` | Request diagnostics |
 | `https://demo.example.com/health` | `/health` | Health check |
+
+### Verify F5 XC Header Injection
+
+Use the whoami endpoint to verify what headers F5 XC injects into requests reaching the origin:
+
+```bash
+LB_DOMAIN="demo.example.com"
+
+curl -sk "https://${LB_DOMAIN}/whoami/"
+```
+
+Look for these F5 XC injected headers in the response:
+
+| Header | Meaning |
+|---|---|
+| `X-Forwarded-For` | Client IP chain through F5 XC |
+| `True-Client-IP` | Original client IP |
+| `X-Forwarded-Proto` | `https` if TLS terminates at F5 XC |
+| `X-Volterra-Bot-Type` | Bot classification (when Bot Defense is enabled) |
+| `X-Request-ID` | F5 XC request tracking ID |
 
 ### WAF Testing Through F5 XC
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,7 +37,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     title="Vulnerable Applications"
-    description="OWASP Juice Shop, DVWA, VAmPI, and httpbin covering XSS, SQLi, API Top 10, and basic HTTP testing."
+    description="Juice Shop, DVWA, VAmPI, httpbin, and whoami covering security testing and request diagnostics."
     href="04-applications/"
   />
   <LinkCard


### PR DESCRIPTION
## Summary

- Add traefik/whoami as a request diagnostics application to the origin server documentation
- whoami displays all HTTP request details (headers, client IP, hostname) as the origin sees them
- Essential for verifying F5 XC header injection (X-Forwarded-For, True-Client-IP, X-Volterra-Bot-Type, etc.) during demos

Closes #5

## Changes

| File | What changed |
| --- | --- |
| `docs/01-architecture.mdx` | Added whoami to Mermaid diagram, app mapping table, and app selection table |
| `docs/03-deploy.mdx` | Added whoami container to docker-compose, nginx location block, health check, landing page HTML, and Terraform output |
| `docs/04-applications.mdx` | Added full whoami section with use cases, examples, and updated coverage matrix |
| `docs/05-verify.mdx` | Added whoami to smoke tests and expected Docker container list |
| `docs/06-integrate.mdx` | Added whoami to path routing table and new "Verify F5 XC Header Injection" section |
| `docs/index.mdx` | Updated application list description |

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Documentation renders correctly with all new whoami sections
- [ ] Mermaid diagram includes whoami container
- [ ] All cross-references between docs pages are consistent