### PR TITLE
feat: add CSD demo application for client-side defense testing

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -29,6 +29,7 @@ graph LR
     NGINX --> |/vampi/| VAMPI[VAmPI<br/>Port 5000]
     NGINX --> |/httpbin/| HTTPBIN[httpbin<br/>Port 8080]
     NGINX --> |/whoami/| WHOAMI[whoami<br/>Port 8082]
+    NGINX --> |/csd-demo/| CSD[CSD Demo<br/>Port 5001]
 ```
 
 The nginx reverse proxy on the VM:
@@ -49,6 +50,7 @@ The nginx reverse proxy on the VM:
 | `/vampi/` | VAmPI | 5000 | REST API security testing (OWASP API Top 10) |
 | `/httpbin/` | httpbin | 8080 | HTTP request/response service for API demos |
 | `/whoami/` | whoami | 8082 | Request diagnostics -- shows all headers, client IP, hostname |
+| `/csd-demo/` | CSD Demo | 5001 | Client-Side Defense testing -- skimming, formjacking, keylogging |
 
 ## Modular Component Design
 
@@ -69,3 +71,4 @@ The human operator adds components one at a time. Each component's documentation
 | **VAmPI** | Purpose-built for OWASP API Security Top 10; REST API with known vulnerabilities; lightweight Flask app |
 | **httpbin** | Kenneth Reitz's canonical HTTP testing service; useful for basic API demos and request inspection |
 | **whoami** | Traefik's request echo server; shows full request details as the origin sees them -- essential for verifying F5 XC header injection |
+| **CSD Demo** | Custom e-commerce checkout with toggleable Magecart skimmer, formjacker, keylogger, cryptominer, and DOM hijack attacks for F5 Client-Side Defense demos |

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -284,6 +284,56 @@ write_files:
           ports:
             - "127.0.0.1:8082:80"
 
+  - path: /opt/origin-server/csd-demo/app.py
+    content: |
+      from datetime import datetime, timezone
+      from flask import Flask, jsonify, render_template, request
+      app = Flask(__name__)
+      exfiltrated_data = []
+      @app.route("/")
+      def checkout():
+          return render_template("checkout.html")
+      @app.route("/dashboard")
+      def dashboard():
+          return render_template("dashboard.html", entries=exfiltrated_data)
+      @app.route("/exfil", methods=["POST", "GET"])
+      def exfil():
+          entry = {"timestamp": datetime.now(timezone.utc).isoformat(),
+                   "source_ip": request.remote_addr,
+                   "user_agent": request.headers.get("User-Agent", ""),
+                   "attack_type": request.args.get("type", "unknown")}
+          if request.is_json:
+              entry["payload"] = request.get_json(silent=True)
+          elif request.args.get("d"):
+              entry["payload"] = request.args.get("d")
+          else:
+              entry["payload"] = request.get_data(as_text=True)
+          exfiltrated_data.append(entry)
+          return jsonify({"status": "received"})
+      @app.route("/exfil/log")
+      def exfil_log():
+          return jsonify(exfiltrated_data)
+      @app.route("/exfil/clear", methods=["POST"])
+      def exfil_clear():
+          exfiltrated_data.clear()
+          return jsonify({"status": "cleared"})
+      @app.route("/health")
+      def health():
+          return jsonify({"status": "healthy", "component": "csd-demo",
+            "attacks": ["skimmer", "formjacker", "keylogger", "cryptominer", "dom-hijack"]})
+      if __name__ == "__main__":
+          app.run(host="0.0.0.0", port=5001, debug=False)
+
+  - path: /opt/origin-server/csd-demo/Dockerfile
+    content: |
+      FROM python:3.12-slim
+      WORKDIR /app
+      RUN pip install --no-cache-dir flask
+      COPY app.py .
+      COPY templates/ templates/
+      EXPOSE 5001
+      CMD ["python", "app.py"]
+
   - path: /etc/nginx/sites-available/origin-server
     content: |
       server {
@@ -292,7 +342,7 @@ write_files:
 
           location /health {
               access_log off;
-              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami"]}';
+              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami","csd-demo"]}';
               add_header Content-Type application/json;
           }
 
@@ -320,6 +370,14 @@ write_files:
 
           location /vampi/ {
               proxy_pass http://127.0.0.1:5000/;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
+          location /csd-demo/ {
+              proxy_pass http://127.0.0.1:5001/;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -357,6 +415,7 @@ write_files:
         <li><a href="/vampi/">VAmPI</a> - REST API security (OWASP API Top 10)</li>
         <li><a href="/httpbin/">httpbin</a> - HTTP request/response testing</li>
         <li><a href="/whoami/">whoami</a> - Request diagnostics (headers, IP, hostname)</li>
+        <li><a href="/csd-demo/">CSD Demo</a> - Client-Side Defense testing (skimming, formjacking)</li>
       </ul>
       <p><a href="/health">Health Check</a></p>
       </body>
@@ -378,6 +437,8 @@ runcmd:
   - cd /opt/origin-server && docker compose up -d
   - sleep 60
   - docker exec vampi python -c "from config import db, vuln_app; vuln_app.app.app_context().__enter__(); db.create_all()"
+  - docker build -t csd-demo:latest /opt/origin-server/csd-demo/
+  - docker run -d --name csd-demo --restart unless-stopped -p 127.0.0.1:5001:5001 csd-demo:latest
   - systemctl restart nginx
 ```
 
@@ -431,6 +492,11 @@ output "whoami_url" {
   value       = "http://${azurerm_public_ip.origin.ip_address}/whoami/"
 }
 
+output "csd_demo_url" {
+  description = "Client-Side Defense demo URL"
+  value       = "http://${azurerm_public_ip.origin.ip_address}/csd-demo/"
+}
+
 output "resource_group" {
   description = "Resource group containing all origin server resources"
   value       = azurerm_resource_group.origin.name
@@ -482,7 +548,7 @@ Expected response:
 {
   "status": "healthy",
   "component": "origin-server",
-  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami"]
+  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo"]
 }
 ```
 

--- a/docs/04-applications.mdx
+++ b/docs/04-applications.mdx
@@ -201,6 +201,62 @@ X-Forwarded-Proto: https
 X-Real-Ip: 104.219.105.84
 ```
 
+## CSD Demo (Client-Side Defense)
+
+| | |
+|---|---|
+| **Path** | `/csd-demo/` |
+| **Image** | Custom (built from Dockerfile in cloud-init) |
+| **Framework** | Python / Flask |
+| **Dashboard** | `/csd-demo/dashboard` |
+
+A purpose-built e-commerce checkout page with five toggleable client-side attack scenarios designed to demonstrate F5 Distributed Cloud Client-Side Defense capabilities. Each attack can be enabled independently via the operator control panel.
+
+### Attack Scenarios
+
+| Attack | Toggle | What CSD Detects |
+|---|---|---|
+| **Card Skimmer** | Magecart-style interception | Unauthorized script reading payment form fields and exfiltrating via XHR to attacker endpoint |
+| **Formjacker** | Hijacks form action URL | Form submission redirected to attacker-controlled domain instead of legitimate backend |
+| **Keylogger** | Real-time keystroke capture | JavaScript listening to keydown events and transmitting keystrokes to external endpoint |
+| **Cryptominer** | Simulated CPU-intensive mining | Unauthorized script consuming CPU resources; communication with mining pool domain |
+| **DOM Hijack** | Injects fake overlay form | Unauthorized DOM manipulation creating phishing overlay to steal credentials |
+
+### Demo Flow
+
+1. Open `/csd-demo/` in the browser
+2. Open `/csd-demo/dashboard` in a second tab (attacker view)
+3. Enable one or more attacks via the red control panel
+4. Fill in the checkout form with test data
+5. Submit the form and observe data appearing in the attacker dashboard
+6. Show how F5 CSD detects and blocks these exfiltration attempts
+
+### CSD Detection Mapping
+
+Based on the [F5 CSD Solution Overview](https://cdn.studio.f5.com/files/k6fem79d/production/6cf856310ae57017926c3ba475c6199c9747d92b.pdf):
+
+| CSD Capability | Demo Attack |
+|---|---|
+| Monitor client-side code for malicious JavaScript | All five attacks |
+| Detect data exfiltration to attacker-controlled domains | Skimmer, Formjacker, Keylogger |
+| Stop account takeovers (session/credential theft) | DOM Hijack, Keylogger |
+| One-click blocking of attacker domains | Skimmer exfil endpoint |
+| PCI DSS 6.4.3 compliance (script inventory) | All -- unauthorized scripts detected |
+| Supply chain attack detection | Skimmer (injected via compromised third-party JS) |
+
+### API Endpoints
+
+```bash
+# Check CSD demo health
+curl "http://<PUBLIC_IP>/csd-demo/health"
+
+# View exfiltration log (attacker C&C)
+curl "http://<PUBLIC_IP>/csd-demo/exfil/log" | jq .
+
+# Clear exfiltration log
+curl -X POST "http://<PUBLIC_IP>/csd-demo/exfil/clear"
+```
+
 ## Application Coverage Matrix
 
 | Demo Use Case | Primary App | Secondary App |
@@ -218,3 +274,9 @@ X-Real-Ip: 104.219.105.84
 | Basic connectivity testing | httpbin | -- |
 | Request diagnostics | whoami | httpbin |
 | Header injection verification | whoami | -- |
+| Client-Side Defense -- Skimming | CSD Demo | -- |
+| Client-Side Defense -- Formjacking | CSD Demo | -- |
+| Client-Side Defense -- Keylogging | CSD Demo | -- |
+| Client-Side Defense -- Cryptomining | CSD Demo | -- |
+| Client-Side Defense -- DOM Hijack | CSD Demo | -- |
+| PCI DSS 6.4.3 compliance | CSD Demo | -- |

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -47,6 +47,9 @@ curl -sf "http://${ORIGIN_IP}/httpbin/get" -o /dev/null -w "httpbin: %{http_code
 
 # whoami
 curl -sf "http://${ORIGIN_IP}/whoami/" -o /dev/null -w "whoami: %{http_code}\n"
+
+# CSD Demo
+curl -sf "http://${ORIGIN_IP}/csd-demo/" -o /dev/null -w "CSD Demo: %{http_code}\n"
 ```
 
 All should return `200`.
@@ -68,6 +71,7 @@ dvwa         Up X minutes   127.0.0.1:8081->80/tcp
 vampi        Up X minutes   127.0.0.1:5000->5000/tcp
 httpbin      Up X minutes   127.0.0.1:8080->80/tcp
 whoami       Up X minutes   127.0.0.1:8082->80/tcp
+csd-demo     Up X minutes   127.0.0.1:5001->5001/tcp
 ```
 
 ### nginx Status

--- a/docs/06-integrate.mdx
+++ b/docs/06-integrate.mdx
@@ -49,6 +49,7 @@ Each application is accessible via its path prefix through the load balancer:
 | `https://demo.example.com/vampi/` | `/vampi/` | VAmPI |
 | `https://demo.example.com/httpbin/` | `/httpbin/` | httpbin |
 | `https://demo.example.com/whoami/` | `/whoami/` | Request diagnostics |
+| `https://demo.example.com/csd-demo/` | `/csd-demo/` | Client-Side Defense testing |
 | `https://demo.example.com/health` | `/health` | Health check |
 
 ### Verify F5 XC Header Injection

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,7 +37,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     title="Vulnerable Applications"
-    description="Juice Shop, DVWA, VAmPI, httpbin, and whoami covering security testing and request diagnostics."
+    description="Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo covering WAF, API, bot, and client-side defense testing."
     href="04-applications/"
   />
   <LinkCard


### PR DESCRIPTION
## Summary

- Add documentation for a purpose-built Client-Side Defense (CSD) demo application with 5 toggleable attack scenarios: Magecart card skimmer, formjacker, keylogger, cryptominer, and DOM hijack
- Includes attacker dashboard, CSD detection mapping, API endpoints, and deployment steps for the origin server
- Enables demonstration of F5 Distributed Cloud CSD capabilities including PCI DSS 6.4.3 compliance testing

Closes #7

## Test plan

- [ ] CI checks pass (linked issue check + lint)
- [ ] Verify architecture diagram renders correctly with CSD Demo node
- [ ] Verify all 6 documentation pages are consistent (deploy, applications, verify, integrate, index, architecture)
- [ ] Confirm smoke test commands and health check endpoints are accurate
- [ ] Validate path routing table includes CSD Demo entry