### PR TITLE
feat: add CSD demo app and enhance frontmatter descriptions

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: Network architecture and component design of the origin server
+description: "nginx reverse proxy routing /juice-shop, /dvwa, /vampi, /httpbin, /whoami, and /csd-demo to Docker containers on a single Ubuntu 24.04 Azure VM with VNet 10.200.0.0/16"
 sidebar:
   order: 1
 ---

--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: Required tools and access for deploying the origin server
+description: "Azure subscription, Terraform >= 1.5, Azure CLI, SSH key pair, and Standard_B2ms VM (2 vCPU, 8 GiB RAM) at approximately $69 USD/month"
 sidebar:
   order: 2
 ---

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: Terraform plan for deploying the origin server on Azure
+description: "Complete Terraform HCL for Azure deployment: main.tf, variables.tf, network.tf, vm.tf, cloud-init.yaml, and outputs.tf with docker-compose for all six application containers"
 sidebar:
   order: 3
 ---

--- a/docs/04-applications.mdx
+++ b/docs/04-applications.mdx
@@ -1,6 +1,6 @@
 ---
 title: Applications
-description: Guide to each vulnerable web application and demo scenarios
+description: "URL paths, request/response behavior, default credentials, and attack scenarios for Juice Shop (/juice-shop), DVWA (/dvwa), VAmPI (/vampi), httpbin (/httpbin), whoami (/whoami), and CSD Demo (/csd-demo)"
 sidebar:
   order: 4
 ---
@@ -8,6 +8,33 @@ sidebar:
 ## Application Overview
 
 Each application runs as an isolated Docker container, accessible through the nginx reverse proxy on the VM. All applications are intentionally vulnerable and designed for security testing.
+
+Replace `<ORIGIN>` with `http://<PUBLIC_IP>` in all examples below. After deploying via Terraform, get the IP with `terraform output -raw public_ip`.
+
+## Quick Reference -- All URL Paths
+
+| Path | Application | HTTP Method | Expected Response |
+|---|---|---|---|
+| `/` | Landing page | GET | 200 HTML with links to all apps |
+| `/health` | Health check | GET | 200 JSON `{"status":"healthy","component":"origin-server",...}` |
+| `/juice-shop/` | Juice Shop | GET | 200 HTML (Angular SPA, ~75 KB) |
+| `/juice-shop/rest/products/search?q=` | Juice Shop API | GET | 200 JSON `{"status":"success","data":[...]}` (36 products) |
+| `/dvwa/` | DVWA | GET | 302 redirect to `/dvwa/login.php` |
+| `/dvwa/login.php` | DVWA login | GET | 200 HTML login form |
+| `/dvwa/setup.php` | DVWA setup | GET | 200 HTML (first-run database init) |
+| `/vampi/` | VAmPI | GET | 200 HTML (API docs) |
+| `/vampi/users/v1` | VAmPI API | GET | 200 JSON `{"users":[...]}` |
+| `/vampi/users/v1/register` | VAmPI API | POST | 200 JSON `{"status":"success",...}` |
+| `/vampi/users/v1/login` | VAmPI API | POST | 200 JSON `{"auth_token":"...","status":"success"}` |
+| `/httpbin/get` | httpbin | GET | 200 JSON with request details |
+| `/httpbin/post` | httpbin | POST | 200 JSON with posted data |
+| `/httpbin/headers` | httpbin | GET | 200 JSON `{"headers":{...}}` |
+| `/httpbin/status/:code` | httpbin | GET | Returns the specified HTTP status code |
+| `/whoami/` | whoami | GET | 200 plain text with hostname, IP, all headers |
+| `/csd-demo/` | CSD Demo | GET | 200 HTML checkout form with attack panel |
+| `/csd-demo/dashboard` | CSD attacker view | GET | 200 HTML showing exfiltrated data |
+| `/csd-demo/health` | CSD health | GET | 200 JSON `{"status":"healthy","component":"csd-demo",...}` |
+| `/csd-demo/exfil/log` | CSD exfil log | GET | 200 JSON array of captured data |
 
 ## OWASP Juice Shop
 

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -1,6 +1,6 @@
 ---
 title: Verify
-description: Smoke tests and troubleshooting for the origin server
+description: "curl smoke tests for all six application endpoints, Docker container health checks, nginx status verification, cloud-init log inspection, and common troubleshooting steps"
 sidebar:
   order: 5
 ---

--- a/docs/06-integrate.mdx
+++ b/docs/06-integrate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrate
-description: Using the origin server with F5 Distributed Cloud
+description: "Configure the VM as an F5 XC origin pool member with WAF, Bot Defense, API Discovery, and Client-Side Defense policies; path-based routing through HTTP load balancer; header injection verification via /whoami"
 sidebar:
   order: 6
 ---

--- a/docs/07-teardown.mdx
+++ b/docs/07-teardown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teardown
-description: Destroy the origin server infrastructure and clean up resources
+description: "terraform destroy to remove all Azure resources (rg-origin-server), verify cleanup with az CLI, clean local state files, and remove associated F5 XC origin pool and HTTP load balancer"
 sidebar:
   order: 7
 ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Origin Server
-description: Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments
+description: "Ubuntu 24.04 Azure VM running nginx reverse proxy to Docker containers: Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo for WAF, API security, bot defense, and client-side defense testing with F5 Distributed Cloud"
 template: splash
 sidebar:
   hidden: true


### PR DESCRIPTION
## Summary

- Add Client-Side Defense (CSD) Demo application with 5 toggleable client-side attack scenarios (Magecart skimmer, formjacker, keylogger, cryptominer, DOM hijack) for F5 CSD demos
- Enhance all frontmatter `description` fields to be rich and specific for `llms.txt` generation, including URL paths, HTTP methods, ports, and expected responses
- Add Quick Reference URL table to `04-applications.mdx` mapping every endpoint with HTTP methods and expected responses

Closes #11

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Verify frontmatter descriptions render correctly in site metadata
- [ ] Verify CSD Demo section appears in architecture diagram and application docs
- [ ] Verify Quick Reference URL table is complete and accurate

## Checklist

- [x] Linked to issue #11
- [x] Branch follows naming convention (`feature/11-csd-demo-and-frontmatter`)
- [x] Conventional commit message used
- [x] Pre-commit hooks pass