### PR TITLE
feat: add endpoint manifest with semantic-release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+---
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/enforce-repo-settings.yml"
+      - ".github/workflows/github-pages-deploy.yml"
+      - ".github/workflows/require-linked-issue.yml"
+      - ".github/workflows/super-linter.yml"
+      - ".github/workflows/dependabot-auto-merge.yml"
+      - ".editorconfig"
+      - ".gitignore"
+      - "CLAUDE.md"
+      - "CONTRIBUTING.md"
+      - "README.md"
+      - "LICENSE"
+      - "release.config.js"
+      - "scripts/**"
+      - ".github/workflows/release.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - run: node scripts/validate-manifest.js
+
+  release:
+    name: Semantic Release
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install semantic-release
+        run: >
+          npm install --no-save
+          semantic-release
+          @semantic-release/commit-analyzer
+          @semantic-release/release-notes-generator
+          @semantic-release/exec
+          @semantic-release/git
+          @semantic-release/github
+
+      - name: Run semantic-release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,120 @@
+{
+  "component": "origin-server",
+  "version": "0.0.0",
+  "generated": "2026-04-25T20:00:00Z",
+  "connection": {
+    "default_port": 80,
+    "health_check": {
+      "path": "/health",
+      "method": "GET",
+      "expected_status": 200
+    }
+  },
+  "applications": [
+    {
+      "name": "juice-shop",
+      "path": "/juice-shop/",
+      "description": "OWASP Juice Shop — modern e-commerce with 100+ security challenges",
+      "container": {
+        "image": "bkimminich/juice-shop",
+        "tag": "latest",
+        "internal_port": 3000
+      },
+      "health_check": {
+        "path": "/juice-shop/rest/admin/application-version",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["waf", "bot-defense", "api-security", "client-side-defense"]
+    },
+    {
+      "name": "dvwa",
+      "path": "/dvwa/",
+      "description": "DVWA — classic WAF testing with adjustable difficulty levels",
+      "container": {
+        "image": "ghcr.io/digininja/dvwa",
+        "tag": "latest",
+        "internal_port": 80
+      },
+      "health_check": {
+        "path": "/dvwa/login.php",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": {
+        "username": "admin",
+        "password": "password"
+      },
+      "demo_features": ["waf", "bot-defense"]
+    },
+    {
+      "name": "vampi",
+      "path": "/vampi/",
+      "description": "VAmPI — REST API with OWASP API Security Top 10 vulnerabilities",
+      "container": {
+        "image": "erev0s/vampi",
+        "tag": "latest",
+        "internal_port": 5000
+      },
+      "health_check": {
+        "path": "/vampi/",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["api-security"]
+    },
+    {
+      "name": "httpbin",
+      "path": "/httpbin/",
+      "description": "httpbin — HTTP request/response echo service for diagnostics",
+      "container": {
+        "image": "kennethreitz/httpbin",
+        "tag": "latest",
+        "internal_port": 80
+      },
+      "health_check": {
+        "path": "/httpbin/get",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["diagnostics"]
+    },
+    {
+      "name": "whoami",
+      "path": "/whoami/",
+      "description": "whoami — request diagnostics showing all headers as the origin sees them",
+      "container": {
+        "image": "traefik/whoami",
+        "tag": "latest",
+        "internal_port": 80
+      },
+      "health_check": {
+        "path": "/whoami/",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["diagnostics", "header-verification"]
+    },
+    {
+      "name": "csd-demo",
+      "path": "/csd-demo/",
+      "description": "CSD Demo — e-commerce checkout with toggleable Magecart attacks",
+      "container": {
+        "image": "f5xc-salesdemos/csd-demo",
+        "tag": "latest",
+        "internal_port": 5001
+      },
+      "health_check": {
+        "path": "/csd-demo/health",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["client-side-defense"]
+    }
+  ]
+}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,29 @@
+export default {
+  branches: ['main'],
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        releaseRules: [
+          { breaking: true, release: 'major' },
+          { type: 'feat', release: 'minor' },
+          { type: 'fix', release: 'patch' },
+          { type: 'perf', release: 'patch' },
+          { type: 'revert', release: 'patch' },
+          { type: 'refactor', release: 'patch' },
+          { type: 'chore', release: 'patch' },
+        ],
+      },
+    ],
+    '@semantic-release/release-notes-generator',
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: semantic-release interpolation token
+    ['@semantic-release/exec', { prepareCmd: 'node scripts/stamp-manifest.js ${nextRelease.version}' }],
+    [
+      '@semantic-release/git',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: semantic-release interpolation token
+      { assets: ['manifest.json'], message: 'chore(release): ${nextRelease.version} [skip ci]' },
+    ],
+    ['@semantic-release/github', { assets: [{ path: 'manifest.json', label: 'Endpoint Manifest' }] }],
+  ],
+};

--- a/scripts/stamp-manifest.js
+++ b/scripts/stamp-manifest.js
@@ -1,0 +1,16 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const version = process.argv[2];
+if (version === undefined || version === '') {
+  console.error('Usage: node stamp-manifest.js <version>');
+  process.exit(1);
+}
+
+const path = 'manifest.json';
+const manifest = JSON.parse(readFileSync(path, 'utf8'));
+
+manifest.version = version;
+manifest.generated = new Date().toISOString();
+
+writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`Stamped manifest.json: version=${version} generated=${manifest.generated}`);

--- a/scripts/validate-manifest.js
+++ b/scripts/validate-manifest.js
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+
+const path = 'manifest.json';
+let manifest;
+let errors = 0;
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  errors++;
+}
+
+function pass(msg) {
+  console.log(`PASS: ${msg}`);
+}
+
+try {
+  manifest = JSON.parse(readFileSync(path, 'utf8'));
+  pass('Valid JSON');
+} catch (e) {
+  fail(`Invalid JSON: ${e.message}`);
+  process.exit(1);
+}
+
+if (manifest.component !== 'origin-server') fail('component must be "origin-server"');
+else pass('component field correct');
+
+if (typeof manifest.version !== 'string') fail('version must be a string');
+else pass(`version: ${manifest.version}`);
+
+if (manifest.connection?.health_check?.path !== '/health') fail('connection.health_check.path must be "/health"');
+else pass('global health check path correct');
+
+if (Array.isArray(manifest.applications) === false) {
+  fail('applications must be an array');
+  process.exit(1);
+}
+pass(`${manifest.applications.length} applications defined`);
+
+const names = new Set();
+for (const app of manifest.applications) {
+  const prefix = `applications[${app.name}]`;
+
+  if (typeof app.name !== 'string' || app.name === '') fail(`${prefix}: name is required`);
+  if (names.has(app.name)) fail(`${prefix}: duplicate name`);
+  names.add(app.name);
+
+  if (typeof app.path !== 'string') fail(`${prefix}: path is required`);
+  else if (app.path.startsWith('/') === false) fail(`${prefix}: path must start with /`);
+  else if (app.path.endsWith('/') === false) fail(`${prefix}: path must end with /`);
+  else pass(`${prefix}: path ${app.path}`);
+
+  if (typeof app.description !== 'string' || app.description === '') fail(`${prefix}: description is required`);
+
+  if (app.health_check?.path === undefined) fail(`${prefix}: health_check.path is required`);
+  else if (app.health_check.path.startsWith(app.path) === false && app.health_check.path !== app.path)
+    fail(`${prefix}: health_check.path "${app.health_check.path}" should start with app path "${app.path}"`);
+  else pass(`${prefix}: health_check ${app.health_check.path}`);
+
+  if (app.container?.image === undefined) fail(`${prefix}: container.image is required`);
+
+  if (Array.isArray(app.demo_features) === false) fail(`${prefix}: demo_features must be an array`);
+}
+
+console.log(`\n${errors === 0 ? 'ALL PASSED' : `${errors} ERRORS`}`);
+process.exit(errors === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Add machine-readable endpoint manifest (`manifest.json`) cataloging all origin-server endpoints
- Add semantic-release configuration (`release.config.js`) to publish the manifest as a GitHub Release artifact
- Add CI scripts for manifest validation and version stamping
- Add release workflow triggered on push to main

Closes #15

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] `scripts/validate-manifest.js` correctly validates the manifest structure
- [ ] Release workflow triggers on merge to main and publishes the manifest artifact