### PR TITLE
perf: add kernel tuning, nginx upstream keepalive, and systemd limits

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -244,6 +244,88 @@ packages:
   - nginx
 
 write_files:
+  - path: /etc/sysctl.d/99-origin-server.conf
+    content: |
+      net.core.somaxconn = 65535
+      net.ipv4.tcp_max_syn_backlog = 65535
+      net.core.netdev_max_backlog = 65535
+      net.ipv4.ip_local_port_range = 1024 65535
+      net.ipv4.tcp_tw_reuse = 1
+      net.ipv4.tcp_fin_timeout = 10
+      net.ipv4.tcp_keepalive_time = 60
+      net.ipv4.tcp_keepalive_intvl = 10
+      net.ipv4.tcp_keepalive_probes = 6
+      net.ipv4.tcp_max_tw_buckets = 2000000
+      net.ipv4.tcp_syncookies = 1
+      net.core.rmem_max = 16777216
+      net.core.wmem_max = 16777216
+      net.ipv4.tcp_rmem = 4096 87380 16777216
+      net.ipv4.tcp_wmem = 4096 65536 16777216
+
+  - path: /etc/nginx/nginx.conf
+    content: |
+      user www-data;
+      worker_processes auto;
+      worker_rlimit_nofile 65535;
+      pid /run/nginx.pid;
+      error_log /var/log/nginx/error.log;
+      include /etc/nginx/modules-enabled/*.conf;
+
+      events {
+          worker_connections 16384;
+          multi_accept on;
+          use epoll;
+      }
+
+      http {
+          sendfile on;
+          tcp_nopush on;
+          tcp_nodelay on;
+          types_hash_max_size 2048;
+          server_tokens off;
+
+          include /etc/nginx/mime.types;
+          default_type application/octet-stream;
+
+          keepalive_timeout 65;
+          keepalive_requests 1000;
+          client_body_timeout 10;
+          client_header_timeout 10;
+          send_timeout 10;
+          reset_timedout_connection on;
+
+          proxy_buffer_size 16k;
+          proxy_buffers 8 16k;
+          proxy_busy_buffers_size 32k;
+          proxy_connect_timeout 5;
+          proxy_read_timeout 30;
+          proxy_send_timeout 10;
+
+          access_log /var/log/nginx/access.log;
+
+          gzip on;
+          gzip_vary on;
+          gzip_proxied any;
+          gzip_comp_level 4;
+          gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+          upstream juice_shop { server 127.0.0.1:3000; keepalive 32; }
+          upstream dvwa        { server 127.0.0.1:8081; keepalive 16; }
+          upstream vampi       { server 127.0.0.1:5000; keepalive 16; }
+          upstream httpbin_up  { server 127.0.0.1:8080; keepalive 16; }
+          upstream whoami_up   { server 127.0.0.1:8082; keepalive 16; }
+          upstream csd_demo    { server 127.0.0.1:5001; keepalive 16; }
+
+          include /etc/nginx/conf.d/*.conf;
+          include /etc/nginx/sites-enabled/*;
+      }
+
+  - path: /etc/systemd/system/nginx.service.d/limits.conf
+    content: |
+      [Service]
+      LimitNOFILE=65535
+      LimitNOFILESoft=65535
+
   - path: /opt/origin-server/docker-compose.yml
     content: |
       services:
@@ -287,12 +369,12 @@ write_files:
   - path: /etc/nginx/sites-available/origin-server
     content: |
       server {
-          listen 80;
+          listen 80 backlog=4096;
           server_name _;
 
           location /health {
               access_log off;
-              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami"]}';
+              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami","csd-demo"]}';
               add_header Content-Type application/json;
           }
 
@@ -302,7 +384,9 @@ write_files:
           }
 
           location /juice-shop/ {
-              proxy_pass http://127.0.0.1:3000/;
+              proxy_pass http://juice_shop/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -311,7 +395,9 @@ write_files:
           }
 
           location /dvwa/ {
-              proxy_pass http://127.0.0.1:8081/;
+              proxy_pass http://dvwa/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -319,7 +405,19 @@ write_files:
           }
 
           location /vampi/ {
-              proxy_pass http://127.0.0.1:5000/;
+              proxy_pass http://vampi/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
+          location /csd-demo/ {
+              proxy_pass http://csd_demo/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -327,7 +425,9 @@ write_files:
           }
 
           location /whoami/ {
-              proxy_pass http://127.0.0.1:8082/;
+              proxy_pass http://whoami_up/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -335,7 +435,9 @@ write_files:
           }
 
           location /httpbin/ {
-              proxy_pass http://127.0.0.1:8080/;
+              proxy_pass http://httpbin_up/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -357,12 +459,16 @@ write_files:
         <li><a href="/vampi/">VAmPI</a> - REST API security (OWASP API Top 10)</li>
         <li><a href="/httpbin/">httpbin</a> - HTTP request/response testing</li>
         <li><a href="/whoami/">whoami</a> - Request diagnostics (headers, IP, hostname)</li>
+        <li><a href="/csd-demo/">CSD Demo</a> - Client-Side Defense testing (skimming, formjacking)</li>
       </ul>
       <p><a href="/health">Health Check</a></p>
       </body>
       </html>
 
 runcmd:
+  # Kernel tuning
+  - sysctl -p /etc/sysctl.d/99-origin-server.conf
+  # Docker
   - install -m 0755 -d /etc/apt/keyrings
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
   - chmod a+r /etc/apt/keyrings/docker.asc
@@ -371,13 +477,18 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   - systemctl enable docker
   - systemctl start docker
+  # nginx (systemd limits applied via write_files above)
+  - systemctl daemon-reload
   - ln -sf /etc/nginx/sites-available/origin-server /etc/nginx/sites-enabled/origin-server
   - rm -f /etc/nginx/sites-enabled/default
   - nginx -t
   - systemctl enable nginx
+  # Start containers
   - cd /opt/origin-server && docker compose up -d
   - sleep 60
   - docker exec vampi python -c "from config import db, vuln_app; vuln_app.app.app_context().__enter__(); db.create_all()"
+  - docker build -t csd-demo:latest /opt/origin-server/csd-demo/
+  - docker run -d --name csd-demo --restart unless-stopped -p 127.0.0.1:5001:5001 csd-demo:latest
   - systemctl restart nginx
 ```
 
@@ -482,7 +593,7 @@ Expected response:
 {
   "status": "healthy",
   "component": "origin-server",
-  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami"]
+  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo"]
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add kernel sysctl tuning for high-concurrency TCP (somaxconn, SYN backlog, ephemeral ports, TCP reuse/timeouts, buffer sizes)
- Rewrite nginx.conf with worker_connections 16384, worker_rlimit_nofile 65535, upstream keepalive pools for all 6 backends, epoll, proxy buffer tuning, and gzip
- Add systemd nginx service override for LimitNOFILE 65535
- Update server block to use named upstreams with HTTP/1.1 keepalive instead of direct 127.0.0.1 proxying
- Add csd-demo to health JSON, landing page, expected responses, and runcmd (Docker build and run)

Closes #17

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] cloud-init YAML is valid
- [ ] All 6 upstream blocks reference named upstreams with keepalive headers
- [ ] Health endpoint JSON includes csd-demo
- [ ] Landing page HTML includes csd-demo link
- [ ] runcmd includes sysctl apply, systemctl daemon-reload, and csd-demo Docker build/run