### PR TITLE
fix: remove @semantic-release/git plugin to avoid branch protection conflict

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -19,11 +19,6 @@ export default {
     '@semantic-release/release-notes-generator',
     // biome-ignore lint/suspicious/noTemplateCurlyInString: semantic-release interpolation token
     ['@semantic-release/exec', { prepareCmd: 'node scripts/stamp-manifest.js ${nextRelease.version}' }],
-    [
-      '@semantic-release/git',
-      // biome-ignore lint/suspicious/noTemplateCurlyInString: semantic-release interpolation token
-      { assets: ['manifest.json'], message: 'chore(release): ${nextRelease.version} [skip ci]' },
-    ],
     ['@semantic-release/github', { assets: [{ path: 'manifest.json', label: 'Endpoint Manifest' }] }],
   ],
 };


### PR DESCRIPTION
## Summary

- Removes the `@semantic-release/git` plugin from `release.config.js`
- The plugin attempted to push the stamped `manifest.json` directly to the protected `main` branch, which was rejected by branch protection (`enforce_admins`) requiring status checks
- The stamped manifest is still published as a GitHub Release artifact via `@semantic-release/github`, which is the intended consumption mechanism

Closes #15

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify `release.config.js` no longer references `@semantic-release/git`
- [ ] Confirm `@semantic-release/github` asset config remains intact for manifest publishing
- [ ] After merge, verify the release workflow completes without branch protection errors