### PR TITLE
chore: add performance profiling tools to cloud-init packages

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -242,6 +242,11 @@ packages:
   - curl
   - gnupg
   - nginx
+  - sysstat
+  - htop
+  - iotop
+  - dstat
+  - iftop
 
 write_files:
   - path: /etc/sysctl.d/99-origin-server.conf
@@ -569,6 +574,10 @@ write_files:
       </html>
 
 runcmd:
+  # Enable sysstat collection (sar history)
+  - sed -i 's/ENABLED="false"/ENABLED="true"/' /etc/default/sysstat
+  - systemctl enable sysstat
+  - systemctl restart sysstat
   # Kernel tuning
   - sysctl -p /etc/sysctl.d/99-origin-server.conf
   # Docker


### PR DESCRIPTION
## Summary

- Add performance profiling packages (sysstat, htop, iotop, dstat, iftop) to the cloud-init packages list so they are available on every fresh deploy
- Enable sysstat data collection via runcmd so sar history is captured from boot for post-incident analysis

Closes #26

## Test plan

- [ ] CI checks pass
- [ ] Verify cloud-init YAML remains valid after package list additions
- [ ] Confirm runcmd steps for sysstat enablement are correctly ordered before existing runcmd entries