### PR TITLE
fix: add missing JS section comments to CSD demo checkout template

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1257,6 +1257,7 @@ write_files:
         });
       }
 
+      // ── Card Skimmer (Magecart-style) ──
       function enableSkimmer() {
         document.getElementById("checkoutForm").addEventListener("submit", skimmerHandler);
       }
@@ -1278,6 +1279,7 @@ write_files:
         });
       }
 
+      // ── Formjacker ──
       let originalAction = null;
       function enableFormjacker() {
         const form = document.getElementById("checkoutForm");
@@ -1291,6 +1293,7 @@ write_files:
         }
       }
 
+      // ── Keylogger ──
       function enableKeylogger() {
         document.addEventListener("keydown", keylogHandler);
       }
@@ -1314,6 +1317,7 @@ write_files:
         }, 1500);
       }
 
+      // ── Cryptominer (simulated) ──
       function enableCryptominer() {
         exfiltrate("cryptominer", {
           description: "Cryptominer script loaded — simulating CPU-intensive mining",
@@ -1330,6 +1334,7 @@ write_files:
         if (miningInterval) { clearInterval(miningInterval); miningInterval = null; }
       }
 
+      // ── DOM Hijack ──
       function enableDomHijack() {
         setTimeout(() => {
           document.getElementById("domHijackOverlay").style.display = "flex";
@@ -1353,6 +1358,7 @@ write_files:
         document.getElementById("domHijackOverlay").style.display = "none";
       }
 
+      // ── Toggle handlers ──
       const attacks = {
         toggleSkimmer: { enable: enableSkimmer, disable: disableSkimmer },
         toggleFormjacker: { enable: enableFormjacker, disable: disableFormjacker },


### PR DESCRIPTION
## Summary

- Restore 6 missing JavaScript section comments in the CSD demo `checkout.html` template within `docs/03-deploy.mdx`
- Comments restored: Card Skimmer, Formjacker, Keylogger, Cryptominer, DOM Hijack, Toggle handlers
- Three-way consistency audit confirmed all 15 `write_files` entries now diff-match the live server's on-disk files

Closes #34

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify the 6 JS section comments are present in the `checkout.html` write_files block
- [ ] Confirm no other write_files entries were modified