### PR TITLE
fix: prevent disk exhaustion from nginx access logs under CDN load testing

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -212,7 +212,7 @@ resource "azurerm_linux_virtual_machine" "origin" {
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
-    disk_size_gb         = 30
+    disk_size_gb         = 60
   }
 
   source_image_reference {
@@ -307,7 +307,7 @@ write_files:
           proxy_read_timeout 30;
           proxy_send_timeout 10;
 
-          access_log /var/log/nginx/access.log;
+          access_log off;
 
           gzip on;
           gzip_vary on;
@@ -376,6 +376,28 @@ write_files:
       [Service]
       LimitNOFILE=65535
       LimitNOFILESoft=65535
+
+  - path: /etc/logrotate.d/nginx-origin
+    content: |
+      /var/log/nginx/*.log {
+          daily
+          rotate 7
+          size 500M
+          compress
+          delaycompress
+          missingok
+          notifempty
+          sharedscripts
+          postrotate
+              nginx -s reopen
+          endscript
+      }
+
+  - path: /etc/systemd/journald.conf.d/origin-server.conf
+    content: |
+      [Journal]
+      SystemMaxUse=200M
+      RuntimeMaxUse=50M
 
   - path: /opt/origin-server/docker-compose.yml
     content: |


### PR DESCRIPTION
## Summary

- Disable nginx `access_log` since the origin server sits behind a CDN and per-request logs have no operational value
- Add logrotate config with daily rotation, 7-day retention, and 500 MB size cap as defense-in-depth for `error.log`
- Add journald size caps (200 MB system, 50 MB runtime) to prevent journald from consuming 100% CPU during log storms
- Increase OS disk from 30 GB to 60 GB for Docker image and build cache headroom

Closes #36

## Test plan

- [ ] CI checks pass
- [ ] Verify cloud-init renders correctly with new `write_files` entries
- [ ] Deploy a test instance and confirm nginx starts with `access_log off`
- [ ] Verify logrotate config is present at `/etc/logrotate.d/nginx-origin`
- [ ] Verify journald config is present at `/etc/systemd/journald.conf.d/origin-server.conf`
- [ ] Confirm OS disk provisions at 60 GB