### PR TITLE
perf: add SO_REUSEPORT to nginx listen directive for CDN load distribution

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -768,7 +768,7 @@ write_files:
   - path: /etc/nginx/sites-available/origin-server
     content: |
       server {
-          listen 80 backlog=4096;
+          listen 80 reuseport backlog=4096;
           server_name _;
 
           location /health {


### PR DESCRIPTION
## Summary

- Add `reuseport` to the nginx `listen` directive in the cloud-init deployment configuration
- Distributes the kernel accept() queue across all nginx worker processes instead of thundering-herd on one socket
- Addresses TIME_WAIT socket peak of 14,938 observed during CDN load testing

Closes #38

## Test plan

- [ ] CI checks pass
- [ ] Verify nginx config renders with `listen 80 reuseport backlog=4096;` after cloud-init
- [ ] Run CDN load test and confirm TIME_WAIT socket count decreases under equivalent traffic