### PR TITLE
perf: increase VAmPI memory limit from 256M to 512M to prevent OOM under load

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -567,7 +567,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 512M
 
         vampi-2:
           image: erev0s/vampi:latest
@@ -582,7 +582,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 512M
 
         vampi-3:
           image: erev0s/vampi:latest
@@ -597,7 +597,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 512M
 
         vampi-4:
           image: erev0s/vampi:latest
@@ -612,7 +612,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 512M
 
         httpbin-1:
           image: kennethreitz/httpbin:latest


### PR DESCRIPTION
## Summary

- Increase VAmPI Docker memory limit from 256M to 512M to prevent OOM-kills under CDN load test traffic
- Steady-state memory is 210-231 MiB (82-90% of 256M) with zero headroom; 512M provides 100% headroom on a 64 GiB VM

Closes #40

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify VAmPI containers start successfully with the new memory limit
- [ ] Confirm no OOM-kills during CDN load testing