### PR TITLE
docs: update all documentation to match 25-container production architecture

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: "nginx reverse proxy routing /juice-shop, /dvwa, /vampi, /httpbin, /whoami, and /csd-demo to Docker containers on a single Ubuntu 24.04 Azure VM with VNet 10.200.0.0/16"
+description: "25-container deployment on Standard_D16s_v3 (16 vCPU, 64 GiB): nginx reverse proxy with reuseport, sticky sessions, and proxy cache routing to 4 load-balanced instances each of Juice Shop, DVWA-FPM, VAmPI, httpbin, whoami, and CSD Demo on Ubuntu 24.04"
 sidebar:
   order: 1
 ---
@@ -22,33 +22,41 @@ This component replaces a real production application server with a purpose-buil
 ```mermaid
 graph LR
     Client[Client Browser] --> XCHLB[F5 XC HTTP LB]
-    XCHLB --> NGINX[nginx Reverse Proxy<br/>Ubuntu 24.04 Azure VM]
-    NGINX --> |/| DEFAULT[nginx default page]
-    NGINX --> |/juice-shop/| JS[Juice Shop<br/>Port 3000]
-    NGINX --> |/dvwa/| DVWA[DVWA<br/>Port 8081]
-    NGINX --> |/vampi/| VAMPI[VAmPI<br/>Port 5000]
-    NGINX --> |/httpbin/| HTTPBIN[httpbin<br/>Port 8080]
-    NGINX --> |/whoami/| WHOAMI[whoami<br/>Port 8082]
+    XCHLB --> NGINX[nginx Reverse Proxy<br/>Ubuntu 24.04 · D16s_v3<br/>reuseport · 16 workers]
+    NGINX --> |/| DEFAULT[Landing Page]
+    NGINX --> |/juice-shop/| JS[Juice Shop ×4<br/>Ports 3001-3004<br/>hash cookie_token · cache]
+    NGINX --> |/dvwa/| DVWA[DVWA-FPM ×4<br/>Ports 8101-8104<br/>hash cookie_PHPSESSID]
+    NGINX --> |/vampi/| VAMPI[VAmPI ×4<br/>Ports 5101-5104<br/>ip_hash · gunicorn]
+    NGINX --> |/httpbin/| HTTPBIN[httpbin ×4<br/>Ports 8201-8204<br/>gunicorn -w 4]
+    NGINX --> |/whoami/| WHOAMI[whoami ×4<br/>Ports 8082-8085]
+    NGINX --> |/csd-demo/| CSD[CSD Demo ×4<br/>Ports 5001-5004<br/>ip_hash · gunicorn -w 1]
+    DVWA --> DB[(MariaDB 10.11<br/>dvwa-db)]
 ```
 
-The nginx reverse proxy on the VM:
+**25 containers** on a Standard_D16s_v3 VM (16 vCPU, 64 GiB RAM, 60 GiB disk).
 
-- **Listens on port 80** for all inbound HTTP traffic
-- **Routes by path prefix** to the appropriate Docker container
-- **Serves a default page** at `/` for health checks and basic connectivity testing
+The nginx reverse proxy:
+
+- **Listens on port 80** with `reuseport` and `backlog=4096` for high-concurrency CDN traffic
+- **Routes by path prefix** to load-balanced upstream pools (4 instances per application)
+- **Sticky sessions** prevent state loss: `hash $cookie_token` for Juice Shop, `hash $cookie_PHPSESSID` for DVWA, `ip_hash` for VAmPI and CSD Demo (SQLite/in-memory state per instance)
+- **Proxy cache** for Juice Shop static assets (10 MB zone, 100 MB max, 60 s TTL)
+- **Access logging disabled** to prevent disk exhaustion under CDN load testing (logrotate as defense-in-depth)
 - **Passes client headers** (`X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`) for origin visibility
+- **Kernel tuning** via sysctl: `somaxconn=65535`, `tcp_tw_reuse=1`, `ip_local_port_range=1024-65535`
 
 ## Application Mapping
 
-| Path | Container | Port | Purpose |
-|---|---|---|---|
-| `/` | nginx default | -- | Health check, basic connectivity |
-| `/health` | nginx | -- | JSON health endpoint |
-| `/juice-shop/` | OWASP Juice Shop | 3000 | Modern web app security (XSS, injection, CSRF) |
-| `/dvwa/` | DVWA | 8081 | Classic WAF testing with adjustable difficulty |
-| `/vampi/` | VAmPI | 5000 | REST API security testing (OWASP API Top 10) |
-| `/httpbin/` | httpbin | 8080 | HTTP request/response service for API demos |
-| `/whoami/` | whoami | 8082 | Request diagnostics -- shows all headers, client IP, hostname |
+| Path | Upstream | Instances | Ports | Sticky Session | Purpose |
+|---|---|---|---|---|---|
+| `/` | nginx | -- | -- | -- | Landing page with links to all apps |
+| `/health` | nginx | -- | -- | -- | JSON health endpoint (6 apps listed) |
+| `/juice-shop/` | juice_shop | 4 | 3001-3004 | `hash $cookie_token` | Modern web app security (XSS, injection, CSRF) |
+| `/dvwa/` | dvwa | 4 + MariaDB | 8101-8104 | `hash $cookie_PHPSESSID` | Classic WAF testing with adjustable difficulty |
+| `/vampi/` | vampi | 4 | 5101-5104 | `ip_hash` | REST API security testing (OWASP API Top 10) |
+| `/httpbin/` | httpbin_up | 4 | 8201-8204 | -- | HTTP request/response service for API demos |
+| `/whoami/` | whoami_up | 4 | 8082-8085 | -- | Request diagnostics -- shows all headers, client IP |
+| `/csd-demo/` | csd_demo | 4 | 5001-5004 | `ip_hash` | Client-Side Defense testing (Magecart attacks) |
 
 ## Modular Component Design
 
@@ -64,8 +72,9 @@ The human operator adds components one at a time. Each component's documentation
 
 | Application | Why Selected |
 |---|---|
-| **Juice Shop** | OWASP flagship project; modern Node.js SPA with 100+ challenges covering the OWASP Top 10; actively maintained |
-| **DVWA** | Industry standard for WAF testing; adjustable security levels (low/medium/high/impossible); PHP-based for diversity |
-| **VAmPI** | Purpose-built for OWASP API Security Top 10; REST API with known vulnerabilities; lightweight Flask app |
-| **httpbin** | Kenneth Reitz's canonical HTTP testing service; useful for basic API demos and request inspection |
+| **Juice Shop** | OWASP flagship project; modern Node.js SPA with 100+ challenges covering the OWASP Top 10; actively maintained; 4 instances with proxy cache |
+| **DVWA** | Industry standard for WAF testing; adjustable security levels (low/medium/high/impossible); custom php-fpm + nginx build for performance; shared MariaDB 10.11 backend |
+| **VAmPI** | Purpose-built for OWASP API Security Top 10; REST API with known vulnerabilities; gunicorn with 4 workers per instance; ip_hash sticky for SQLite consistency |
+| **httpbin** | Kenneth Reitz's canonical HTTP testing service; gunicorn with 4 gevent workers; useful for API demos and request inspection |
 | **whoami** | Traefik's request echo server; shows full request details as the origin sees them -- essential for verifying F5 XC header injection |
+| **CSD Demo** | Custom checkout page with 5 toggleable Magecart-style attacks (card skimmer, formjacker, keylogger, cryptominer, DOM hijack); exfil endpoint + attacker dashboard; gunicorn single-worker for in-memory state persistence |

--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: "Azure subscription, Terraform >= 1.5, Azure CLI, SSH key pair, and Standard_B2ms VM (2 vCPU, 8 GiB RAM) at approximately $69 USD/month"
+description: "Azure subscription, Terraform >= 1.5, Azure CLI, SSH key pair, and Standard_D16s_v3 VM (16 vCPU, 64 GiB RAM) for 25-container deployment"
 sidebar:
   order: 2
 ---
@@ -15,7 +15,7 @@ An active Azure subscription with permission to create:
 - Virtual networks and subnets
 - Network security groups
 - Public IP addresses
-- Virtual machines (Standard_B2ms or equivalent -- 2 vCPU, 8 GiB RAM)
+- Virtual machines (Standard_D16s_v3 -- 16 vCPU, 64 GiB RAM for 25-container workloads)
 
 ### Azure CLI
 
@@ -57,16 +57,16 @@ ssh-keygen -t ed25519 -f ~/.ssh/origin-server-key -N ""
 
 | Resource | SKU | Estimated Monthly Cost |
 |---|---|---|
-| Ubuntu 24.04 VM | Standard_B2ms (2 vCPU, 8 GiB) | ~$60 USD |
+| Ubuntu 24.04 VM | Standard_D16s_v3 (16 vCPU, 64 GiB) | ~$486 USD |
 | Public IP | Standard, Static | ~$4 USD |
-| OS Disk | 30 GiB Premium SSD | ~$5 USD |
+| OS Disk | 60 GiB Premium SSD | ~$10 USD |
 | VNet + NSG | -- | No additional cost |
-| **Total** | | **~$69 USD/month** |
+| **Total** | | **~$500 USD/month** |
 
 :::tip
 Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](../07-teardown/) for the procedure.
 :::
 
 :::note
-Standard_B2ms (8 GiB RAM) is recommended because Juice Shop and DVWA each consume ~512 MiB RAM, and Docker overhead adds ~1 GiB. Standard_B2s (4 GiB) will work but may be tight under load.
+Standard_D16s_v3 (64 GiB RAM) is required for the 25-container deployment. Container memory allocation: 4 Juice Shop instances at 1 GiB each (4 GiB), 4 VAmPI at 512 MiB each (2 GiB), 4 DVWA-FPM + MariaDB (1.8 GiB), 4 httpbin at 256 MiB (1 GiB), 4 CSD Demo at 256 MiB (1 GiB), 4 whoami at 64 MiB (256 MiB), plus nginx, OS, and buffer cache. Total container allocation is approximately 10 GiB.
 :::

--- a/docs/04-applications.mdx
+++ b/docs/04-applications.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Application Overview
 
-Each application runs as an isolated Docker container, accessible through the nginx reverse proxy on the VM. All applications are intentionally vulnerable and designed for security testing.
+Each application runs as 4 load-balanced Docker containers behind nginx upstream pools, accessible through the nginx reverse proxy on the VM. Sticky sessions ensure stateful applications (Juice Shop, DVWA, VAmPI, CSD Demo) route consistently. All applications are intentionally vulnerable and designed for security testing.
 
 Replace `<ORIGIN>` with `http://<PUBLIC_IP>` in all examples below. After deploying via Terraform, get the IP with `terraform output -raw public_ip`.
 
@@ -42,6 +42,8 @@ Replace `<ORIGIN>` with `http://<PUBLIC_IP>` in all examples below. After deploy
 |---|---|
 | **Path** | `/juice-shop/` |
 | **Image** | `bkimminich/juice-shop:latest` |
+| **Instances** | 4 (ports 3001-3004), sticky via `hash $cookie_token`, proxy cache (60 s TTL) |
+| **Resources** | 2 CPU / 1 GiB RAM per instance |
 | **Framework** | Node.js / Angular |
 | **Project** | [owasp.org/www-project-juice-shop](https://owasp.org/www-project-juice-shop/) |
 
@@ -70,8 +72,11 @@ curl -s "http://<PUBLIC_IP>/juice-shop/" -o /dev/null -w "%{http_code}"
 | | |
 |---|---|
 | **Path** | `/dvwa/` |
-| **Image** | `ghcr.io/digininja/dvwa:latest` |
-| **Framework** | PHP / MySQL |
+| **Image** | Custom `dvwa-fpm:latest` (php-fpm + nginx, built from `ghcr.io/digininja/dvwa:latest`) |
+| **Instances** | 4 (ports 8101-8104), sticky via `hash $cookie_PHPSESSID` |
+| **Resources** | 0.5 CPU / 256 MiB RAM per instance |
+| **Database** | Shared MariaDB 10.11 (`dvwa-db` container, 1 CPU / 768 MiB) |
+| **Framework** | PHP 8 / php-fpm / MariaDB |
 | **Credentials** | `admin` / `password` |
 
 DVWA is the industry standard for WAF testing. It has adjustable security levels (Low, Medium, High, Impossible) that progressively add input validation and output encoding.
@@ -110,11 +115,13 @@ DVWA requires a one-time database setup after first deployment:
 | | |
 |---|---|
 | **Path** | `/vampi/` |
-| **Image** | `erev0s/vampi:latest` |
-| **Framework** | Python / Flask |
+| **Image** | `erev0s/vampi:latest` with gunicorn entrypoint (4 workers) |
+| **Instances** | 4 (ports 5101-5104), sticky via `ip_hash` (SQLite per instance) |
+| **Resources** | 0.5 CPU / 512 MiB RAM per instance |
+| **Framework** | Python / Flask / gunicorn |
 | **Project** | [github.com/erev0s/VAmPI](https://github.com/erev0s/VAmPI) |
 
-VAmPI is purpose-built for testing the OWASP API Security Top 10. It provides a realistic REST API with deliberate vulnerabilities.
+VAmPI is purpose-built for testing the OWASP API Security Top 10. It provides a realistic REST API with deliberate vulnerabilities. Each instance runs gunicorn with 4 workers and its own SQLite database. The `ip_hash` sticky session ensures registration and login from the same client IP always hit the same instance.
 
 ### Demo Scenarios
 
@@ -149,8 +156,10 @@ curl "http://<PUBLIC_IP>/vampi/users/v1"
 | | |
 |---|---|
 | **Path** | `/httpbin/` |
-| **Image** | `kennethreitz/httpbin:latest` |
-| **Framework** | Python / Flask |
+| **Image** | `kennethreitz/httpbin:latest` with gunicorn CMD override (`-w 4 -k gevent --timeout 30`) |
+| **Instances** | 4 (ports 8201-8204), round-robin (stateless) |
+| **Resources** | 0.5 CPU / 256 MiB RAM per instance |
+| **Framework** | Python / Flask / gunicorn + gevent |
 | **Project** | [httpbin.org](https://httpbin.org) |
 
 httpbin is a simple HTTP request/response service useful for basic API demos, testing request headers, and verifying proxy behavior.
@@ -184,6 +193,8 @@ curl -s -o /dev/null -w "%{http_code}" "http://<PUBLIC_IP>/httpbin/status/403"
 |---|---|
 | **Path** | `/whoami/` |
 | **Image** | `traefik/whoami:latest` |
+| **Instances** | 4 (ports 8082-8085), round-robin (stateless) |
+| **Resources** | 0.25 CPU / 64 MiB RAM per instance |
 | **Framework** | Go |
 | **Project** | [github.com/traefik/whoami](https://github.com/traefik/whoami) |
 
@@ -242,6 +253,11 @@ X-Real-Ip: 104.219.105.84
 | Bot Defense -- Scraping | Juice Shop | -- |
 | Client-Side Defense -- DOM XSS | Juice Shop | -- |
 | Client-Side Defense -- Stored XSS | DVWA | Juice Shop |
+| Client-Side Defense -- Card Skimmer | CSD Demo | -- |
+| Client-Side Defense -- Formjacker | CSD Demo | -- |
+| Client-Side Defense -- Keylogger | CSD Demo | -- |
+| Client-Side Defense -- Cryptominer | CSD Demo | -- |
+| Client-Side Defense -- DOM Hijack | CSD Demo | -- |
 | Basic connectivity testing | httpbin | -- |
 | Request diagnostics | whoami | httpbin |
 | Header injection verification | whoami | -- |

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -23,7 +23,7 @@ Expected:
 {
   "status": "healthy",
   "component": "origin-server",
-  "applications": ["juice-shop", "dvwa", "vampi", "httpbin"]
+  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo"]
 }
 ```
 
@@ -49,25 +49,55 @@ curl -sf "http://${ORIGIN_IP}/httpbin/get" -o /dev/null -w "httpbin: %{http_code
 curl -sf "http://${ORIGIN_IP}/whoami/" -o /dev/null -w "whoami: %{http_code}\n"
 ```
 
-All should return `200`.
+All should return `200` (DVWA returns `302` redirect to login).
+
+### Automated Smoke Test
+
+The repository includes a 39-point smoke test suite:
+
+```bash
+./tests/smoke-test.sh ${ORIGIN_IP}
+```
+
+This validates all 6 applications, health endpoints, VAmPI registration/login, CSD Demo exfil round-trip, nginx gzip, and version hiding.
 
 ### Docker Container Status
 
-SSH into the VM and verify all containers are running:
+SSH into the VM and verify all 25 containers are running:
 
 ```bash
-ssh azureuser@${ORIGIN_IP} "docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
+ssh azureuser@${ORIGIN_IP} "sudo docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'" | sort
 ```
 
-Expected output:
+Expected output (25 containers):
 
 ```
-NAMES        STATUS         PORTS
-juice-shop   Up X minutes   127.0.0.1:3000->3000/tcp
-dvwa         Up X minutes   127.0.0.1:8081->80/tcp
-vampi        Up X minutes   127.0.0.1:5000->5000/tcp
-httpbin      Up X minutes   127.0.0.1:8080->80/tcp
-whoami       Up X minutes   127.0.0.1:8082->80/tcp
+NAMES          STATUS         PORTS
+csd-demo-1     Up X minutes   127.0.0.1:5001->5001/tcp
+csd-demo-2     Up X minutes   127.0.0.1:5002->5001/tcp
+csd-demo-3     Up X minutes   127.0.0.1:5003->5001/tcp
+csd-demo-4     Up X minutes   127.0.0.1:5004->5001/tcp
+dvwa-1         Up X minutes   127.0.0.1:8101->80/tcp
+dvwa-2         Up X minutes   127.0.0.1:8102->80/tcp
+dvwa-3         Up X minutes   127.0.0.1:8103->80/tcp
+dvwa-4         Up X minutes   127.0.0.1:8104->80/tcp
+dvwa-db        Up X minutes   3306/tcp
+httpbin-1      Up X minutes   127.0.0.1:8201->80/tcp
+httpbin-2      Up X minutes   127.0.0.1:8202->80/tcp
+httpbin-3      Up X minutes   127.0.0.1:8203->80/tcp
+httpbin-4      Up X minutes   127.0.0.1:8204->80/tcp
+juice-shop-1   Up X minutes   127.0.0.1:3001->3000/tcp
+juice-shop-2   Up X minutes   127.0.0.1:3002->3000/tcp
+juice-shop-3   Up X minutes   127.0.0.1:3003->3000/tcp
+juice-shop-4   Up X minutes   127.0.0.1:3004->3000/tcp
+vampi-1        Up X minutes   127.0.0.1:5101->5000/tcp
+vampi-2        Up X minutes   127.0.0.1:5102->5000/tcp
+vampi-3        Up X minutes   127.0.0.1:5103->5000/tcp
+vampi-4        Up X minutes   127.0.0.1:5104->5000/tcp
+whoami-1       Up X minutes   127.0.0.1:8082->80/tcp
+whoami-2       Up X minutes   127.0.0.1:8083->80/tcp
+whoami-3       Up X minutes   127.0.0.1:8084->80/tcp
+whoami-4       Up X minutes   127.0.0.1:8085->80/tcp
 ```
 
 ### nginx Status
@@ -99,11 +129,12 @@ ssh azureuser@${ORIGIN_IP} "sudo tail -100 /var/log/cloud-init-output.log"
 ### Container not starting
 
 ```bash
-# Check container logs
-ssh azureuser@${ORIGIN_IP} "docker logs juice-shop 2>&1 | tail -20"
-ssh azureuser@${ORIGIN_IP} "docker logs dvwa 2>&1 | tail -20"
-ssh azureuser@${ORIGIN_IP} "docker logs vampi 2>&1 | tail -20"
-ssh azureuser@${ORIGIN_IP} "docker logs httpbin 2>&1 | tail -20"
+# Check container logs (each app has 4 instances: -1 through -4)
+ssh azureuser@${ORIGIN_IP} "sudo docker logs juice-shop-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs dvwa-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs vampi-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs httpbin-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs csd-demo-1 2>&1 | tail -20"
 ```
 
 ### nginx returning 502
@@ -114,25 +145,33 @@ The upstream container is not ready or has crashed:
 # Check nginx error log
 ssh azureuser@${ORIGIN_IP} "sudo tail -20 /var/log/nginx/error.log"
 
-# Restart a specific container
-ssh azureuser@${ORIGIN_IP} "cd /opt/origin-server && docker compose restart juice-shop"
+# Restart all instances of a specific app
+ssh azureuser@${ORIGIN_IP} "for i in 1 2 3 4; do sudo docker restart juice-shop-\$i; done"
 
-# Restart all containers
-ssh azureuser@${ORIGIN_IP} "cd /opt/origin-server && docker compose restart"
+# Rebuild and restart all containers
+ssh azureuser@${ORIGIN_IP} "cd /opt/origin-server && sudo docker compose build && sudo docker compose up -d"
 ```
 
 ### Disk space
 
-Docker images consume approximately 2 GiB total. Verify disk usage:
+Docker images consume approximately 4.7 GiB. Access logging is disabled to prevent disk exhaustion under CDN load testing. Logrotate is configured as defense-in-depth (500 MiB cap). Verify disk usage:
 
 ```bash
-ssh azureuser@${ORIGIN_IP} "df -h / && docker system df"
+ssh azureuser@${ORIGIN_IP} "df -h / && sudo docker system df"
+```
+
+### Container memory
+
+Check for containers approaching their memory limits (OOM risk):
+
+```bash
+ssh azureuser@${ORIGIN_IP} "sudo docker stats --no-stream --format 'table {{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}' | sort"
 ```
 
 ### Restart everything
 
-If needed, restart all services:
+If needed, rebuild and restart all services:
 
 ```bash
-ssh azureuser@${ORIGIN_IP} "cd /opt/origin-server && docker compose down && docker compose up -d && sudo systemctl restart nginx"
+ssh azureuser@${ORIGIN_IP} "cd /opt/origin-server && sudo docker compose down && sudo docker compose build && sudo docker compose up -d && sudo systemctl restart nginx"
 ```

--- a/docs/06-integrate.mdx
+++ b/docs/06-integrate.mdx
@@ -44,12 +44,13 @@ Each application is accessible via its path prefix through the load balancer:
 
 | F5 XC LB URL | Origin Path | Application |
 |---|---|---|
-| `https://demo.example.com/juice-shop/` | `/juice-shop/` | Juice Shop |
-| `https://demo.example.com/dvwa/` | `/dvwa/` | DVWA |
-| `https://demo.example.com/vampi/` | `/vampi/` | VAmPI |
-| `https://demo.example.com/httpbin/` | `/httpbin/` | httpbin |
-| `https://demo.example.com/whoami/` | `/whoami/` | Request diagnostics |
-| `https://demo.example.com/health` | `/health` | Health check |
+| `https://demo.example.com/juice-shop/` | `/juice-shop/` | Juice Shop (4 instances, cookie sticky) |
+| `https://demo.example.com/dvwa/` | `/dvwa/` | DVWA (4 instances + MariaDB, cookie sticky) |
+| `https://demo.example.com/vampi/` | `/vampi/` | VAmPI (4 instances, ip_hash sticky) |
+| `https://demo.example.com/httpbin/` | `/httpbin/` | httpbin (4 instances, round-robin) |
+| `https://demo.example.com/whoami/` | `/whoami/` | Request diagnostics (4 instances) |
+| `https://demo.example.com/csd-demo/` | `/csd-demo/` | CSD Demo (4 instances, ip_hash sticky) |
+| `https://demo.example.com/health` | `/health` | Health check (nginx direct) |
 
 ### Verify F5 XC Header Injection
 
@@ -106,6 +107,21 @@ curl -sk -X POST "https://${LB_DOMAIN}/vampi/users/v1/login" \
   -H "Content-Type: application/json" \
   -d '{"username":"apitest","password":"test123"}'
 ```
+
+### Sticky Session Awareness
+
+The origin server uses nginx sticky sessions internally to route stateful applications to consistent backend containers. When configuring the F5 XC HTTP load balancer, be aware:
+
+| Application | Sticky Method | Why |
+|---|---|---|
+| Juice Shop | `hash $cookie_token` | Node.js session state |
+| DVWA | `hash $cookie_PHPSESSID` | PHP session state |
+| VAmPI | `ip_hash` | SQLite database per instance |
+| CSD Demo | `ip_hash` | In-memory exfil log per instance |
+| httpbin | Round-robin | Stateless |
+| whoami | Round-robin | Stateless |
+
+F5 XC does not need to replicate these sticky sessions -- nginx on the origin VM handles the backend routing. F5 XC should treat the origin as a single endpoint (the VM's public IP on port 80).
 
 ### Multi-Component Architecture
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -27,17 +27,17 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     title="Multi-App Origin"
-    description="One Ubuntu 24.04 VM running nginx as a reverse proxy to Juice Shop, DVWA, VAmPI, and httpbin containers."
+    description="One Ubuntu 24.04 VM (16 vCPU, 64 GiB) running nginx as a reverse proxy to 25 Docker containers: Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo — each scaled to 4 load-balanced instances."
     href="01-architecture/"
   />
   <LinkCard
     title="Terraform Deployment"
-    description="Complete Azure infrastructure as code: VNet, PIP, NSG, and VM with Docker + nginx cloud-init provisioning."
+    description="Complete Azure infrastructure as code: VNet, PIP, NSG, and Standard_D16s_v3 VM with Docker + nginx cloud-init provisioning. 60 GiB disk, logrotate, and journald caps included."
     href="03-deploy/"
   />
   <LinkCard
     title="Vulnerable Applications"
-    description="Juice Shop, DVWA, VAmPI, httpbin, and whoami covering security testing and request diagnostics."
+    description="Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo covering WAF, API security, bot defense, client-side defense, and request diagnostics."
     href="04-applications/"
   />
   <LinkCard

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,11 @@
       "container": {
         "image": "bkimminich/juice-shop",
         "tag": "latest",
-        "internal_port": 3000
+        "internal_port": 3000,
+        "instances": 4,
+        "host_ports": "3001-3004",
+        "sticky": "hash $cookie_token consistent",
+        "resources": "2 CPU / 1024M"
       },
       "health_check": {
         "path": "/juice-shop/rest/admin/application-version",
@@ -33,9 +37,15 @@
       "path": "/dvwa/",
       "description": "DVWA — classic WAF testing with adjustable difficulty levels",
       "container": {
-        "image": "ghcr.io/digininja/dvwa",
+        "image": "dvwa-fpm",
         "tag": "latest",
-        "internal_port": 80
+        "build": true,
+        "internal_port": 80,
+        "instances": 4,
+        "host_ports": "8101-8104",
+        "sticky": "hash $cookie_PHPSESSID consistent",
+        "resources": "0.5 CPU / 256M",
+        "database": "mariadb:10.11 (dvwa-db, 1 CPU / 768M)"
       },
       "health_check": {
         "path": "/dvwa/login.php",
@@ -55,7 +65,12 @@
       "container": {
         "image": "erev0s/vampi",
         "tag": "latest",
-        "internal_port": 5000
+        "internal_port": 5000,
+        "instances": 4,
+        "host_ports": "5101-5104",
+        "sticky": "ip_hash",
+        "entrypoint": "gunicorn -w 4",
+        "resources": "0.5 CPU / 512M"
       },
       "health_check": {
         "path": "/vampi/",
@@ -72,7 +87,11 @@
       "container": {
         "image": "kennethreitz/httpbin",
         "tag": "latest",
-        "internal_port": 80
+        "internal_port": 80,
+        "instances": 4,
+        "host_ports": "8201-8204",
+        "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent -w 4 --timeout 30",
+        "resources": "0.5 CPU / 256M"
       },
       "health_check": {
         "path": "/httpbin/get",
@@ -89,7 +108,10 @@
       "container": {
         "image": "traefik/whoami",
         "tag": "latest",
-        "internal_port": 80
+        "internal_port": 80,
+        "instances": 4,
+        "host_ports": "8082-8085",
+        "resources": "0.25 CPU / 64M"
       },
       "health_check": {
         "path": "/whoami/",
@@ -104,9 +126,15 @@
       "path": "/csd-demo/",
       "description": "CSD Demo — e-commerce checkout with toggleable Magecart attacks",
       "container": {
-        "image": "f5xc-salesdemos/csd-demo",
+        "image": "csd-demo-gunicorn",
         "tag": "latest",
-        "internal_port": 5001
+        "build": true,
+        "internal_port": 5001,
+        "instances": 4,
+        "host_ports": "5001-5004",
+        "sticky": "ip_hash",
+        "command": "gunicorn -b 0.0.0.0:5001 app:app -w 1 -k gevent --timeout 30",
+        "resources": "0.5 CPU / 256M"
       },
       "health_check": {
         "path": "/csd-demo/health",


### PR DESCRIPTION
## Summary

- Update all 6 documentation pages and manifest.json to accurately reflect the 25-container production architecture built across 29 PRs
- Architecture diagram updated with 4 instances per app, sticky sessions, proxy cache, reuseport, MariaDB
- Prerequisites updated to Standard_D16s_v3 (16 vCPU, 64 GiB), 60 GiB disk, ~$500/month
- Applications page updated with instance counts, port ranges, resource limits, gunicorn workers, DVWA-FPM custom build, CSD Demo attack types
- Verify page corrected with 6-app health endpoint response, 25-container docker ps output, smoke-test.sh reference
- Integrate page updated with CSD Demo path and sticky session awareness table for F5 XC
- manifest.json corrected with local build images for CSD/DVWA, instance counts, ports, sticky methods, resources

Closes #42

## Test plan

- [ ] CI checks pass (lint, spell check, Biome)
- [ ] GitHub Pages docs site builds and deploys successfully
- [ ] All mermaid diagrams render correctly
- [ ] manifest.json is valid JSON
- [ ] Documentation accurately reflects the 25-container architecture