### PR TITLE
docs: add llms-config.json for llms.txt hierarchy

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,16 @@
+{
+  "customSets": [
+    {
+      "label": "Deployment Guide",
+      "description": "Step-by-step deployment from architecture through teardown",
+      "paths": ["01-architecture*", "02-prerequisites*", "03-deploy*", "04-applications*", "05-verify*"]
+    },
+    {
+      "label": "Integration",
+      "description": "Integration with F5 XC HTTP load balancers and WAF policies",
+      "paths": ["06-integrate*"]
+    }
+  ],
+  "promote": ["index*", "01-architecture*", "03-deploy*"],
+  "demote": ["07-teardown*"]
+}


### PR DESCRIPTION
## Summary

- Adds `docs/llms-config.json` with customSets for Deployment Guide and Integration topics
- Configures promote and demote lists for tiered content output in the starlight-llms-txt plugin

Refs f5xc-salesdemos/xcsh#223

Step 5 of the cascading llms.txt knowledge hierarchy -- adds `llms-config.json` with custom sets, promote, and demote lists so the starlight-llms-txt plugin generates tiered content output.

Closes #44

## Test plan

- [ ] CI checks pass
- [ ] Verify llms-config.json is valid JSON and matches the starlight-llms-txt plugin schema
- [ ] Confirm the docs site builds successfully with the new config