### PR TITLE
feat: add DVGA, RESTaurant API, and crAPI for comprehensive API security testing

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: "25-container deployment on Standard_D16s_v3 (16 vCPU, 64 GiB): nginx reverse proxy with reuseport, sticky sessions, and proxy cache routing to 4 load-balanced instances each of Juice Shop, DVWA-FPM, VAmPI, httpbin, whoami, and CSD Demo on Ubuntu 24.04"
+description: "41-container deployment on Standard_D16s_v3 (16 vCPU, 64 GiB): nginx reverse proxy with reuseport, sticky sessions, and proxy cache routing to load-balanced instances of Juice Shop, DVWA-FPM, VAmPI, httpbin, whoami, CSD Demo, DVGA, RESTaurant, and crAPI on Ubuntu 24.04"
 sidebar:
   order: 1
 ---
@@ -30,10 +30,14 @@ graph LR
     NGINX --> |/httpbin/| HTTPBIN[httpbin ×4<br/>Ports 8201-8204<br/>gunicorn -w 4]
     NGINX --> |/whoami/| WHOAMI[whoami ×4<br/>Ports 8082-8085]
     NGINX --> |/csd-demo/| CSD[CSD Demo ×4<br/>Ports 5001-5004<br/>ip_hash · gunicorn -w 1]
+    NGINX --> |/dvga/| DVGA[DVGA ×4<br/>Ports 5201-5204<br/>ip_hash · SQLite]
+    NGINX --> |/restaurant/| REST[RESTaurant ×4<br/>Ports 8301-8304<br/>round-robin]
+    XCHLB --> |:8888| CRAPI[crAPI ×7 microservices<br/>Port 8888<br/>web · identity · community<br/>workshop · postgres · mongo · mailhog]
     DVWA --> DB[(MariaDB 10.11<br/>dvwa-db)]
+    REST --> RESTDB[(PostgreSQL 15.4<br/>restaurant-db)]
 ```
 
-**25 containers** on a Standard_D16s_v3 VM (16 vCPU, 64 GiB RAM, 60 GiB disk).
+**41 containers** on a Standard_D16s_v3 VM (16 vCPU, 64 GiB RAM, 60 GiB disk).
 
 The nginx reverse proxy:
 
@@ -50,13 +54,16 @@ The nginx reverse proxy:
 | Path | Upstream | Instances | Ports | Sticky Session | Purpose |
 |---|---|---|---|---|---|
 | `/` | nginx | -- | -- | -- | Landing page with links to all apps |
-| `/health` | nginx | -- | -- | -- | JSON health endpoint (6 apps listed) |
+| `/health` | nginx | -- | -- | -- | JSON health endpoint (9 apps listed) |
 | `/juice-shop/` | juice_shop | 4 | 3001-3004 | `hash $cookie_token` | Modern web app security (XSS, injection, CSRF) |
 | `/dvwa/` | dvwa | 4 + MariaDB | 8101-8104 | `hash $cookie_PHPSESSID` | Classic WAF testing with adjustable difficulty |
 | `/vampi/` | vampi | 4 | 5101-5104 | `ip_hash` | REST API security testing (OWASP API Top 10) |
 | `/httpbin/` | httpbin_up | 4 | 8201-8204 | -- | HTTP request/response service for API demos |
 | `/whoami/` | whoami_up | 4 | 8082-8085 | -- | Request diagnostics -- shows all headers, client IP |
 | `/csd-demo/` | csd_demo | 4 | 5001-5004 | `ip_hash` | Client-Side Defense testing (Magecart attacks) |
+| `/dvga/` | dvga | 4 | 5201-5204 | `ip_hash` | GraphQL API security testing (injection, DoS, auth bypass) |
+| `/restaurant/` | restaurant | 4 + PostgreSQL | 8301-8304 | -- | REST API security (OWASP API Top 10 2023) |
+| `:8888` | crapi | 7 microservices | 8888 | -- | OWASP crAPI (BOLA, BFLA, mass assignment, SSRF, JWT) |
 
 ## Modular Component Design
 
@@ -78,3 +85,6 @@ The human operator adds components one at a time. Each component's documentation
 | **httpbin** | Kenneth Reitz's canonical HTTP testing service; gunicorn with 4 gevent workers; useful for API demos and request inspection |
 | **whoami** | Traefik's request echo server; shows full request details as the origin sees them -- essential for verifying F5 XC header injection |
 | **CSD Demo** | Custom checkout page with 5 toggleable Magecart-style attacks (card skimmer, formjacker, keylogger, cryptominer, DOM hijack); exfil endpoint + attacker dashboard; gunicorn single-worker for in-memory state persistence |
+| **DVGA** | Damn Vulnerable GraphQL Application; GraphQL-specific vulnerabilities including injection, DoS, batching attacks, and authorization bypass; GraphiQL UI for interactive exploration; ip_hash sticky for SQLite per instance |
+| **RESTaurant** | Damn Vulnerable RESTaurant API Game; purpose-built for OWASP API Security Top 10 2023; FastAPI with Swagger UI; shared PostgreSQL 15.4 backend; covers BOLA, BFLA, mass assignment, SSRF, and injection |
+| **crAPI** | OWASP Completely Ridiculous API; 7-microservice architecture covering BOLA, BFLA, mass assignment, SSRF, JWT manipulation, and NoSQL injection; dedicated port 8888 (SPA with hardcoded API paths); MailHog for email capture |

--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: "Azure subscription, Terraform >= 1.5, Azure CLI, SSH key pair, and Standard_D16s_v3 VM (16 vCPU, 64 GiB RAM) for 25-container deployment"
+description: "Azure subscription, Terraform >= 1.5, Azure CLI, SSH key pair, and Standard_D16s_v3 VM (16 vCPU, 64 GiB RAM) for 41-container deployment"
 sidebar:
   order: 2
 ---
@@ -15,7 +15,7 @@ An active Azure subscription with permission to create:
 - Virtual networks and subnets
 - Network security groups
 - Public IP addresses
-- Virtual machines (Standard_D16s_v3 -- 16 vCPU, 64 GiB RAM for 25-container workloads)
+- Virtual machines (Standard_D16s_v3 -- 16 vCPU, 64 GiB RAM for 41-container workloads)
 
 ### Azure CLI
 
@@ -68,5 +68,9 @@ Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See
 :::
 
 :::note
-Standard_D16s_v3 (64 GiB RAM) is required for the 25-container deployment. Container memory allocation: 4 Juice Shop instances at 1 GiB each (4 GiB), 4 VAmPI at 512 MiB each (2 GiB), 4 DVWA-FPM + MariaDB (1.8 GiB), 4 httpbin at 256 MiB (1 GiB), 4 CSD Demo at 256 MiB (1 GiB), 4 whoami at 64 MiB (256 MiB), plus nginx, OS, and buffer cache. Total container allocation is approximately 10 GiB.
+Standard_D16s_v3 (64 GiB RAM) is required for the 41-container deployment. Container memory allocation: 4 Juice Shop instances at 1 GiB each (4 GiB), 4 VAmPI at 512 MiB each (2 GiB), 4 DVWA-FPM + MariaDB (1.8 GiB), 4 httpbin at 256 MiB (1 GiB), 4 CSD Demo at 256 MiB (1 GiB), 4 whoami at 64 MiB (256 MiB), 4 DVGA at 256 MiB each (1 GiB), 4 RESTaurant + PostgreSQL (1.5 GiB), crAPI 7 microservices (2 GiB), plus nginx, OS, and buffer cache. Total container allocation is approximately 14.5 GiB (22.7% of 64 GiB).
+:::
+
+:::note
+The NSG allows inbound traffic on ports 80 (HTTP) and 8888 (crAPI). Port 8888 is required because crAPI is a single-page application that hardcodes its API paths and cannot be served behind a path prefix.
 :::

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: "Complete Terraform HCL for Azure deployment: main.tf, variables.tf, network.tf, vm.tf, cloud-init.yaml, and outputs.tf with docker-compose for all six application containers"
+description: "Complete Terraform HCL for Azure deployment: main.tf, variables.tf, network.tf, vm.tf, cloud-init.yaml, and outputs.tf with docker-compose for 41 containers across 9 applications"
 sidebar:
   order: 3
 ---
@@ -160,6 +160,18 @@ resource "azurerm_network_security_group" "origin" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowCrAPI"
+    priority                   = 130
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "8888"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
@@ -364,6 +376,23 @@ write_files:
               server 127.0.0.1:5003 max_fails=3 fail_timeout=10s;
               server 127.0.0.1:5004 max_fails=3 fail_timeout=10s;
               ip_hash;
+              keepalive 32;
+          }
+
+          upstream dvga_graphql {
+              server 127.0.0.1:5201 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:5202 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:5203 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:5204 max_fails=3 fail_timeout=10s;
+              ip_hash;
+              keepalive 32;
+          }
+
+          upstream restaurant {
+              server 127.0.0.1:8301 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:8302 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:8303 max_fails=3 fail_timeout=10s;
+              server 127.0.0.1:8304 max_fails=3 fail_timeout=10s;
               keepalive 32;
           }
 
@@ -762,8 +791,409 @@ write_files:
                 cpus: "0.5"
                 memory: 256M
 
+        dvga-1:
+          image: dolevf/dvga:latest
+          container_name: dvga-1
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5201:5013"
+          environment:
+            - WEB_HOST=0.0.0.0
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        dvga-2:
+          image: dolevf/dvga:latest
+          container_name: dvga-2
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5202:5013"
+          environment:
+            - WEB_HOST=0.0.0.0
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        dvga-3:
+          image: dolevf/dvga:latest
+          container_name: dvga-3
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5203:5013"
+          environment:
+            - WEB_HOST=0.0.0.0
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        dvga-4:
+          image: dolevf/dvga:latest
+          container_name: dvga-4
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:5204:5013"
+          environment:
+            - WEB_HOST=0.0.0.0
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        restaurant-db:
+          image: postgres:15.4-alpine
+          container_name: restaurant-db
+          restart: unless-stopped
+          environment:
+            - POSTGRES_USER=admin
+            - POSTGRES_PASSWORD=password
+            - POSTGRES_DB=restaurant
+            - PGDATA=/var/lib/postgresql/data/pgdata
+          volumes:
+            - restaurant-db-data:/var/lib/postgresql/data
+          healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U admin -d restaurant"]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 512M
+
+        restaurant-1:
+          build: ./restaurant/
+          container_name: restaurant-1
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8301:8091"
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          environment:
+            - POSTGRES_USER=admin
+            - POSTGRES_PASSWORD=password
+            - POSTGRES_SERVER=restaurant-db
+            - POSTGRES_PORT=5432
+            - POSTGRES_DB=restaurant
+          depends_on:
+            restaurant-db:
+              condition: service_healthy
+          cap_add:
+            - SYS_ADMIN
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        restaurant-2:
+          build: ./restaurant/
+          container_name: restaurant-2
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8302:8091"
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          environment:
+            - POSTGRES_USER=admin
+            - POSTGRES_PASSWORD=password
+            - POSTGRES_SERVER=restaurant-db
+            - POSTGRES_PORT=5432
+            - POSTGRES_DB=restaurant
+          depends_on:
+            restaurant-db:
+              condition: service_healthy
+          cap_add:
+            - SYS_ADMIN
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        restaurant-3:
+          build: ./restaurant/
+          container_name: restaurant-3
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8303:8091"
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          environment:
+            - POSTGRES_USER=admin
+            - POSTGRES_PASSWORD=password
+            - POSTGRES_SERVER=restaurant-db
+            - POSTGRES_PORT=5432
+            - POSTGRES_DB=restaurant
+          depends_on:
+            restaurant-db:
+              condition: service_healthy
+          cap_add:
+            - SYS_ADMIN
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        restaurant-4:
+          build: ./restaurant/
+          container_name: restaurant-4
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:8304:8091"
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          environment:
+            - POSTGRES_USER=admin
+            - POSTGRES_PASSWORD=password
+            - POSTGRES_SERVER=restaurant-db
+            - POSTGRES_PORT=5432
+            - POSTGRES_DB=restaurant
+          depends_on:
+            restaurant-db:
+              condition: service_healthy
+          cap_add:
+            - SYS_ADMIN
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        crapi-web:
+          image: crapi/crapi-web:latest
+          container_name: crapi-web
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:18888:80"
+          environment:
+            - COMMUNITY_SERVICE=crapi-community:8087
+            - IDENTITY_SERVICE=crapi-identity:8080
+            - WORKSHOP_SERVICE=crapi-workshop:8000
+            - CHATBOT_SERVICE=crapi-identity:8080
+            - MAILHOG_WEB_SERVICE=crapi-mailhog:8025
+            - TLS_ENABLED=false
+          depends_on:
+            crapi-identity:
+              condition: service_healthy
+            crapi-community:
+              condition: service_healthy
+            crapi-workshop:
+              condition: service_healthy
+          healthcheck:
+            test: ["CMD", "curl", "-f", "http://0.0.0.0:80/health"]
+            interval: 15s
+            timeout: 15s
+            retries: 15
+          deploy:
+            resources:
+              limits:
+                cpus: "0.3"
+                memory: 128M
+
+        crapi-identity:
+          image: crapi/crapi-identity:latest
+          container_name: crapi-identity
+          restart: unless-stopped
+          environment:
+            - LOG_LEVEL=INFO
+            - DB_NAME=crapi
+            - DB_USER=admin
+            - DB_PASSWORD=crapisecretpassword
+            - DB_HOST=crapi-postgres
+            - DB_PORT=5432
+            - SERVER_PORT=8080
+            - ENABLE_SHELL_INJECTION=true
+            - JWT_SECRET=crapi
+            - JWT_EXPIRATION=604800000
+            - MAILHOG_HOST=crapi-mailhog
+            - MAILHOG_PORT=1025
+            - MAILHOG_DOMAIN=example.com
+            - SMTP_HOST=crapi-mailhog
+            - SMTP_PORT=1025
+            - SMTP_EMAIL=user@example.com
+            - SMTP_PASS=xxxxxxxxxxxxxx
+            - SMTP_FROM=no-reply@example.com
+            - SMTP_AUTH=false
+            - SMTP_STARTTLS=false
+            - ENABLE_LOG4J=true
+            - API_GATEWAY_URL=https://api.mypremiumdealership.com
+            - MONGO_DB_HOST=crapi-mongo
+            - MONGO_DB_PORT=27017
+            - MONGO_DB_USER=admin
+            - MONGO_DB_PASSWORD=crapisecretpassword
+            - MONGO_DB_NAME=crapi
+            - TLS_ENABLED=false
+          depends_on:
+            crapi-postgres:
+              condition: service_healthy
+            crapi-mongo:
+              condition: service_healthy
+            crapi-mailhog:
+              condition: service_healthy
+          healthcheck:
+            test: ["CMD", "/app/health.sh"]
+            interval: 15s
+            timeout: 15s
+            retries: 15
+          deploy:
+            resources:
+              limits:
+                cpus: "0.8"
+                memory: 512M
+
+        crapi-community:
+          image: crapi/crapi-community:latest
+          container_name: crapi-community
+          restart: unless-stopped
+          environment:
+            - LOG_LEVEL=INFO
+            - IDENTITY_SERVICE=crapi-identity:8080
+            - DB_NAME=crapi
+            - DB_USER=admin
+            - DB_PASSWORD=crapisecretpassword
+            - DB_HOST=crapi-postgres
+            - DB_PORT=5432
+            - SERVER_PORT=8087
+            - MONGO_DB_HOST=crapi-mongo
+            - MONGO_DB_PORT=27017
+            - MONGO_DB_USER=admin
+            - MONGO_DB_PASSWORD=crapisecretpassword
+            - MONGO_DB_NAME=crapi
+            - TLS_ENABLED=false
+          depends_on:
+            crapi-mongo:
+              condition: service_healthy
+            crapi-identity:
+              condition: service_healthy
+          healthcheck:
+            test: ["CMD", "/app/health.sh"]
+            interval: 15s
+            timeout: 15s
+            retries: 15
+          deploy:
+            resources:
+              limits:
+                cpus: "0.3"
+                memory: 192M
+
+        crapi-workshop:
+          image: crapi/crapi-workshop:latest
+          container_name: crapi-workshop
+          restart: unless-stopped
+          environment:
+            - LOG_LEVEL=INFO
+            - IDENTITY_SERVICE=crapi-identity:8080
+            - DB_NAME=crapi
+            - DB_USER=admin
+            - DB_PASSWORD=crapisecretpassword
+            - DB_HOST=crapi-postgres
+            - DB_PORT=5432
+            - SERVER_PORT=8000
+            - MONGO_DB_HOST=crapi-mongo
+            - MONGO_DB_PORT=27017
+            - MONGO_DB_USER=admin
+            - MONGO_DB_PASSWORD=crapisecretpassword
+            - MONGO_DB_NAME=crapi
+            - SECRET_KEY=crapi
+            - API_GATEWAY_URL=https://api.mypremiumdealership.com
+            - TLS_ENABLED=false
+            - FILES_LIMIT=1000
+          depends_on:
+            crapi-postgres:
+              condition: service_healthy
+            crapi-mongo:
+              condition: service_healthy
+            crapi-identity:
+              condition: service_healthy
+            crapi-community:
+              condition: service_healthy
+          healthcheck:
+            test: ["CMD", "/app/health.sh"]
+            interval: 15s
+            timeout: 15s
+            retries: 15
+          deploy:
+            resources:
+              limits:
+                cpus: "0.3"
+                memory: 256M
+
+        crapi-postgres:
+          image: postgres:14
+          container_name: crapi-postgres
+          restart: unless-stopped
+          environment:
+            - POSTGRES_USER=admin
+            - POSTGRES_PASSWORD=crapisecretpassword
+            - POSTGRES_DB=crapi
+          volumes:
+            - crapi-postgres-data:/var/lib/postgresql/data
+          healthcheck:
+            test: ["CMD-SHELL", "pg_isready"]
+            interval: 15s
+            timeout: 15s
+            retries: 10
+          deploy:
+            resources:
+              limits:
+                cpus: "0.5"
+                memory: 256M
+
+        crapi-mongo:
+          image: mongo:4.4
+          container_name: crapi-mongo
+          restart: unless-stopped
+          environment:
+            - MONGO_INITDB_ROOT_USERNAME=admin
+            - MONGO_INITDB_ROOT_PASSWORD=crapisecretpassword
+          volumes:
+            - crapi-mongo-data:/data/db
+          healthcheck:
+            test: ["CMD", "mongo", "--eval", "db.runCommand(\"ping\").ok", "--quiet"]
+            interval: 15s
+            timeout: 15s
+            retries: 10
+            start_period: 20s
+          deploy:
+            resources:
+              limits:
+                cpus: "0.3"
+                memory: 128M
+
+        crapi-mailhog:
+          image: crapi/mailhog:latest
+          container_name: crapi-mailhog
+          restart: unless-stopped
+          ports:
+            - "127.0.0.1:18025:8025"
+          environment:
+            - MH_MONGO_URI=admin:crapisecretpassword@crapi-mongo:27017
+            - MH_STORAGE=mongodb
+          depends_on:
+            crapi-mongo:
+              condition: service_healthy
+          healthcheck:
+            test: ["CMD", "nc", "-z", "localhost", "8025"]
+            interval: 15s
+            timeout: 15s
+            retries: 10
+          deploy:
+            resources:
+              limits:
+                cpus: "0.3"
+                memory: 128M
+
       volumes:
         dvwa-db-data:
+        restaurant-db-data:
+        crapi-postgres-data:
+        crapi-mongo-data:
 
   - path: /etc/nginx/sites-available/origin-server
     content: |
@@ -773,7 +1203,7 @@ write_files:
 
           location /health {
               access_log off;
-              return 200 '{ "status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami","csd-demo"] }' ;
+              return 200 '{ "status":"healthy","component":"origin-server","applications":["juice-shop","dvwa","vampi","httpbin","whoami","csd-demo","dvga","restaurant","crapi"] }' ;
               add_header Content-Type application/json;
           }
 
@@ -846,6 +1276,47 @@ write_files:
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header X-Forwarded-Proto $scheme;
           }
+
+          location /dvga/ {
+              proxy_pass http://dvga_graphql/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
+
+          location /restaurant/ {
+              proxy_pass http://restaurant/;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
+      }
+
+      server {
+          listen 8888;
+          server_name _;
+
+          location /health {
+              access_log off;
+              return 200 '{"status":"healthy","component":"crapi"}';
+              add_header Content-Type application/json;
+          }
+
+          location / {
+              proxy_pass http://127.0.0.1:18888;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+          }
       }
 
   - path: /var/www/html/index.html
@@ -863,6 +1334,9 @@ write_files:
         <li><a href="/httpbin/">httpbin</a> - HTTP request/response testing</li>
         <li><a href="/whoami/">whoami</a> - Request diagnostics (headers, IP, hostname)</li>
         <li><a href="/csd-demo/">CSD Demo</a> - Client-Side Defense testing (skimming, formjacking)</li>
+        <li><a href="/dvga/">DVGA</a> - GraphQL security (introspection, batching, injection)</li>
+        <li><a href="/restaurant/">RESTaurant</a> - REST API security (OWASP API Top 10 2023)</li>
+        <li><a href="javascript:void(0)" onclick="window.open('http://'+location.hostname+':8888','_blank')">crAPI</a> - Microservices API security (BOLA, BFLA, SSRF)</li>
       </ul>
       <p><a href="/health">Health Check</a></p>
       </body>
@@ -1502,6 +1976,9 @@ runcmd:
   - rm -f /etc/nginx/sites-enabled/default
   - nginx -t
   - systemctl enable nginx
+  # Clone RESTaurant API repo for build
+  - apt-get install -y git
+  - git clone --depth 1 https://github.com/theowni/Damn-Vulnerable-RESTaurant-API-Game.git /opt/origin-server/restaurant
   # Build custom images and start all containers
   - cd /opt/origin-server && docker compose build
   - cd /opt/origin-server && docker compose up -d
@@ -1568,6 +2045,21 @@ output "whoami_url" {
   value       = "http://${azurerm_public_ip.origin.ip_address}/whoami/"
 }
 
+output "dvga_url" {
+  description = "DVGA GraphQL security URL"
+  value       = "http://${azurerm_public_ip.origin.ip_address}/dvga/"
+}
+
+output "restaurant_url" {
+  description = "RESTaurant API security URL"
+  value       = "http://${azurerm_public_ip.origin.ip_address}/restaurant/"
+}
+
+output "crapi_url" {
+  description = "crAPI microservices security URL"
+  value       = "http://${azurerm_public_ip.origin.ip_address}:8888"
+}
+
 output "resource_group" {
   description = "Resource group containing all origin server resources"
   value       = azurerm_resource_group.origin.name
@@ -1619,7 +2111,7 @@ Expected response:
 {
   "status": "healthy",
   "component": "origin-server",
-  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo"]
+  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo", "dvga", "restaurant", "crapi"]
 }
 ```
 

--- a/docs/04-applications.mdx
+++ b/docs/04-applications.mdx
@@ -1,6 +1,6 @@
 ---
 title: Applications
-description: "URL paths, request/response behavior, default credentials, and attack scenarios for Juice Shop (/juice-shop), DVWA (/dvwa), VAmPI (/vampi), httpbin (/httpbin), whoami (/whoami), and CSD Demo (/csd-demo)"
+description: "URL paths, request/response behavior, default credentials, and attack scenarios for Juice Shop (/juice-shop), DVWA (/dvwa), VAmPI (/vampi), httpbin (/httpbin), whoami (/whoami), CSD Demo (/csd-demo), DVGA (/dvga), RESTaurant (/restaurant), and crAPI (:8888)"
 sidebar:
   order: 4
 ---
@@ -35,6 +35,14 @@ Replace `<ORIGIN>` with `http://<PUBLIC_IP>` in all examples below. After deploy
 | `/csd-demo/dashboard` | CSD attacker view | GET | 200 HTML showing exfiltrated data |
 | `/csd-demo/health` | CSD health | GET | 200 JSON `{"status":"healthy","component":"csd-demo",...}` |
 | `/csd-demo/exfil/log` | CSD exfil log | GET | 200 JSON array of captured data |
+| `/dvga/` | DVGA GraphiQL | GET | 200 HTML (GraphiQL IDE) |
+| `/dvga/graphql` | DVGA GraphQL API | POST | 200 JSON GraphQL response |
+| `/restaurant/` | RESTaurant | GET | 200 (redirects to docs) |
+| `/restaurant/docs` | RESTaurant Swagger | GET | 200 HTML (FastAPI Swagger UI) |
+| `/restaurant/openapi.json` | RESTaurant OpenAPI | GET | 200 JSON OpenAPI spec |
+| `http://<PUBLIC_IP>:8888` | crAPI | GET | 200 HTML (SPA) |
+| `http://<PUBLIC_IP>:8888/identity/api/auth/signup` | crAPI signup | POST | 200 JSON |
+| `http://<PUBLIC_IP>:8888/identity/api/auth/login` | crAPI login | POST | 200 JSON `{"token":"..."}` |
 
 ## OWASP Juice Shop
 
@@ -239,6 +247,157 @@ X-Forwarded-Proto: https
 X-Real-Ip: 104.219.105.84
 ```
 
+## DVGA (Damn Vulnerable GraphQL Application)
+
+| | |
+|---|---|
+| **Path** | `/dvga/` |
+| **Image** | `dolevf/dvga:latest` |
+| **Instances** | 4 (ports 5201-5204), sticky via `ip_hash` (SQLite per instance) |
+| **Resources** | 0.5 CPU / 256 MiB RAM per instance |
+| **Framework** | Python / Flask / GraphQL |
+| **Project** | [github.com/dolevf/Damn-Vulnerable-GraphQL-Application](https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application) |
+
+DVGA is purpose-built for testing GraphQL-specific vulnerabilities. It provides a GraphiQL IDE at `/dvga/` for interactive query exploration and a GraphQL API endpoint at `/dvga/graphql`. Each instance uses its own SQLite database, so `ip_hash` sticky sessions ensure consistent state.
+
+### Demo Scenarios
+
+| Scenario | Category | Attack Vector |
+|---|---|---|
+| GraphQL Injection | API Security | Malicious queries via string interpolation |
+| Denial of Service | API Security | Deeply nested queries, batch queries, resource exhaustion |
+| Authorization Bypass | API Security | Accessing unauthorized data through GraphQL |
+| Information Disclosure | API Security | Introspection queries revealing schema details |
+| Batching Attack | API Security | Multiple operations in a single request |
+
+### Key Endpoints
+
+```bash
+# GraphiQL UI (interactive IDE)
+curl -sf "http://<PUBLIC_IP>/dvga/" -o /dev/null -w "%{http_code}"
+
+# Introspection query -- enumerate the full schema
+curl -s "http://<PUBLIC_IP>/dvga/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ __schema { types { name fields { name } } } }"}'
+
+# List pastes (example query)
+curl -s "http://<PUBLIC_IP>/dvga/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ pastes { title content } }"}'
+
+# Create a paste (mutation)
+curl -s "http://<PUBLIC_IP>/dvga/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"mutation { createPaste(title:\"test\", content:\"hello\", public:true) { paste { title } } }"}'
+```
+
+## RESTaurant (Damn Vulnerable RESTaurant API Game)
+
+| | |
+|---|---|
+| **Path** | `/restaurant/` |
+| **Image** | Custom build from `theowni/Damn-Vulnerable-RESTaurant-API-Game` |
+| **Instances** | 4 (ports 8301-8304), round-robin (shared PostgreSQL) |
+| **Resources** | 0.5 CPU / 256 MiB RAM per instance |
+| **Database** | Shared PostgreSQL 15.4 (`restaurant-db` container, 0.5 CPU / 512 MiB) |
+| **Framework** | Python / FastAPI / PostgreSQL |
+| **Credentials** | `admin` / `password` (PostgreSQL) |
+| **Project** | [github.com/theowni/Damn-Vulnerable-RESTaurant-API-Game](https://github.com/theowni/Damn-Vulnerable-RESTaurant-API-Game) |
+
+RESTaurant is a gamified vulnerable REST API covering the OWASP API Security Top 10 2023. It uses FastAPI with automatic Swagger UI documentation at `/restaurant/docs`. All 4 instances share a single PostgreSQL database, so round-robin load balancing works without sticky sessions.
+
+### Demo Scenarios
+
+| Scenario | OWASP API Top 10 2023 | Method |
+|---|---|---|
+| Broken Object Level Authorization (BOLA) | API1 | Access other users' orders by manipulating IDs |
+| Broken Authentication | API2 | Weak token handling, credential stuffing |
+| Broken Object Property Level Authorization | API3 | Mass assignment on user profile fields |
+| Unrestricted Resource Consumption | API4 | No rate limiting on endpoints |
+| Broken Function Level Authorization (BFLA) | API5 | Access admin endpoints as regular user |
+| Server Side Request Forgery (SSRF) | API7 | Manipulate server-side URL requests |
+| Security Misconfiguration | API8 | Verbose error messages, default credentials |
+
+### Key Endpoints
+
+```bash
+# Swagger UI
+curl -sf "http://<PUBLIC_IP>/restaurant/docs" -o /dev/null -w "%{http_code}"
+
+# OpenAPI spec
+curl -s "http://<PUBLIC_IP>/restaurant/openapi.json" | jq .info
+
+# BOLA -- access another user's order (after authentication)
+curl -s "http://<PUBLIC_IP>/restaurant/orders/1" \
+  -H "Authorization: Bearer <token>"
+
+# BFLA -- attempt admin action as regular user
+curl -s -X POST "http://<PUBLIC_IP>/restaurant/admin/users" \
+  -H "Authorization: Bearer <user_token>" \
+  -H "Content-Type: application/json"
+```
+
+## crAPI (OWASP Completely Ridiculous API)
+
+| | |
+|---|---|
+| **Port** | `8888` (dedicated -- not path-prefixed) |
+| **Images** | `crapi/crapi-web`, `crapi/crapi-identity`, `crapi/crapi-community`, `crapi/crapi-workshop`, PostgreSQL, MongoDB, MailHog |
+| **Instances** | 7 microservices (single instance each) |
+| **Resources** | ~3.0 CPU / ~2.0 GiB RAM total |
+| **Framework** | React SPA + Java/Go/Python microservices |
+| **Project** | [github.com/OWASP/crAPI](https://github.com/OWASP/crAPI) |
+
+crAPI is the OWASP flagship project for API security testing. It runs as 7 microservices on a dedicated port (8888) because the React SPA hardcodes its API paths and cannot be served behind a path prefix. The NSG allows inbound traffic on port 8888.
+
+MailHog captures all emails sent by crAPI (account verification, password reset). Access MailHog via SSH tunnel on port 18025.
+
+### Challenge Categories
+
+| Category | Vulnerabilities |
+|---|---|
+| BOLA (Broken Object Level Authorization) | Access other users' vehicles, orders, and reports |
+| BFLA (Broken Function Level Authorization) | Escalate to admin, access restricted endpoints |
+| Mass Assignment | Modify protected fields (role, balance) via API |
+| SSRF (Server Side Request Forgery) | Manipulate server-side URL fetching |
+| JWT Manipulation | Forge or modify JWT tokens for privilege escalation |
+| NoSQL Injection | Inject queries into MongoDB-backed endpoints |
+| Excessive Data Exposure | API returns sensitive user data |
+
+### Getting Started
+
+```bash
+# Verify crAPI is running
+curl -sf "http://<PUBLIC_IP>:8888" -o /dev/null -w "%{http_code}"
+
+# Sign up a new user
+curl -s -X POST "http://<PUBLIC_IP>:8888/identity/api/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test User","email":"test@example.com","number":"1234567890","password":"Test1234!"}'
+
+# Log in
+curl -s -X POST "http://<PUBLIC_IP>:8888/identity/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"Test1234!"}'
+
+# Access MailHog (via SSH tunnel for email verification)
+# ssh -L 18025:localhost:18025 azureuser@<PUBLIC_IP>
+# Then open http://localhost:18025 in your browser
+```
+
+### crAPI Architecture
+
+```
+Port 8888 -> crapi-web (React SPA + nginx)
+             -> crapi-identity (Java, user auth, JWT)
+             -> crapi-community (Go, forums, posts)
+             -> crapi-workshop (Python, vehicle service)
+             -> crapi-postgres (PostgreSQL)
+             -> crapi-mongo (MongoDB)
+             -> crapi-mailhog (email capture, port 18025)
+```
+
 ## Application Coverage Matrix
 
 | Demo Use Case | Primary App | Secondary App |
@@ -258,6 +417,14 @@ X-Real-Ip: 104.219.105.84
 | Client-Side Defense -- Keylogger | CSD Demo | -- |
 | Client-Side Defense -- Cryptominer | CSD Demo | -- |
 | Client-Side Defense -- DOM Hijack | CSD Demo | -- |
+| API Security -- GraphQL injection | DVGA | -- |
+| API Security -- GraphQL DoS | DVGA | -- |
+| API Security -- OWASP API Top 10 2023 | RESTaurant | crAPI |
+| API Security -- BFLA | RESTaurant | crAPI |
+| API Security -- Mass assignment | crAPI | RESTaurant |
+| API Security -- SSRF | crAPI | RESTaurant |
+| API Security -- JWT manipulation | crAPI | -- |
+| API Security -- NoSQL injection | crAPI | -- |
 | Basic connectivity testing | httpbin | -- |
 | Request diagnostics | whoami | httpbin |
 | Header injection verification | whoami | -- |

--- a/docs/05-verify.mdx
+++ b/docs/05-verify.mdx
@@ -1,6 +1,6 @@
 ---
 title: Verify
-description: "curl smoke tests for all six application endpoints, Docker container health checks, nginx status verification, cloud-init log inspection, and common troubleshooting steps"
+description: "curl smoke tests for all nine application endpoints, Docker container health checks, nginx status verification, cloud-init log inspection, and common troubleshooting steps"
 sidebar:
   order: 5
 ---
@@ -23,7 +23,7 @@ Expected:
 {
   "status": "healthy",
   "component": "origin-server",
-  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo"]
+  "applications": ["juice-shop", "dvwa", "vampi", "httpbin", "whoami", "csd-demo", "dvga", "restaurant", "crapi"]
 }
 ```
 
@@ -47,6 +47,15 @@ curl -sf "http://${ORIGIN_IP}/httpbin/get" -o /dev/null -w "httpbin: %{http_code
 
 # whoami
 curl -sf "http://${ORIGIN_IP}/whoami/" -o /dev/null -w "whoami: %{http_code}\n"
+
+# DVGA
+curl -sf "http://${ORIGIN_IP}/dvga/" -o /dev/null -w "DVGA: %{http_code}\n"
+
+# RESTaurant
+curl -sf "http://${ORIGIN_IP}/restaurant/docs" -o /dev/null -w "RESTaurant: %{http_code}\n"
+
+# crAPI (port 8888)
+curl -sf "http://${ORIGIN_IP}:8888" -o /dev/null -w "crAPI: %{http_code}\n"
 ```
 
 All should return `200` (DVWA returns `302` redirect to login).
@@ -59,45 +68,61 @@ The repository includes a 39-point smoke test suite:
 ./tests/smoke-test.sh ${ORIGIN_IP}
 ```
 
-This validates all 6 applications, health endpoints, VAmPI registration/login, CSD Demo exfil round-trip, nginx gzip, and version hiding.
+This validates all 9 applications, health endpoints, VAmPI registration/login, CSD Demo exfil round-trip, DVGA GraphQL, RESTaurant Swagger, crAPI on port 8888, nginx gzip, and version hiding.
 
 ### Docker Container Status
 
-SSH into the VM and verify all 25 containers are running:
+SSH into the VM and verify all 41 containers are running:
 
 ```bash
 ssh azureuser@${ORIGIN_IP} "sudo docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'" | sort
 ```
 
-Expected output (25 containers):
+Expected output (41 containers):
 
 ```
-NAMES          STATUS         PORTS
-csd-demo-1     Up X minutes   127.0.0.1:5001->5001/tcp
-csd-demo-2     Up X minutes   127.0.0.1:5002->5001/tcp
-csd-demo-3     Up X minutes   127.0.0.1:5003->5001/tcp
-csd-demo-4     Up X minutes   127.0.0.1:5004->5001/tcp
-dvwa-1         Up X minutes   127.0.0.1:8101->80/tcp
-dvwa-2         Up X minutes   127.0.0.1:8102->80/tcp
-dvwa-3         Up X minutes   127.0.0.1:8103->80/tcp
-dvwa-4         Up X minutes   127.0.0.1:8104->80/tcp
-dvwa-db        Up X minutes   3306/tcp
-httpbin-1      Up X minutes   127.0.0.1:8201->80/tcp
-httpbin-2      Up X minutes   127.0.0.1:8202->80/tcp
-httpbin-3      Up X minutes   127.0.0.1:8203->80/tcp
-httpbin-4      Up X minutes   127.0.0.1:8204->80/tcp
-juice-shop-1   Up X minutes   127.0.0.1:3001->3000/tcp
-juice-shop-2   Up X minutes   127.0.0.1:3002->3000/tcp
-juice-shop-3   Up X minutes   127.0.0.1:3003->3000/tcp
-juice-shop-4   Up X minutes   127.0.0.1:3004->3000/tcp
-vampi-1        Up X minutes   127.0.0.1:5101->5000/tcp
-vampi-2        Up X minutes   127.0.0.1:5102->5000/tcp
-vampi-3        Up X minutes   127.0.0.1:5103->5000/tcp
-vampi-4        Up X minutes   127.0.0.1:5104->5000/tcp
-whoami-1       Up X minutes   127.0.0.1:8082->80/tcp
-whoami-2       Up X minutes   127.0.0.1:8083->80/tcp
-whoami-3       Up X minutes   127.0.0.1:8084->80/tcp
-whoami-4       Up X minutes   127.0.0.1:8085->80/tcp
+NAMES              STATUS         PORTS
+crapi-community    Up X minutes
+crapi-identity     Up X minutes
+crapi-mailhog      Up X minutes   0.0.0.0:18025->8025/tcp
+crapi-mongo        Up X minutes   27017/tcp
+crapi-postgres     Up X minutes   5432/tcp
+crapi-web          Up X minutes   0.0.0.0:8888->80/tcp
+crapi-workshop     Up X minutes
+csd-demo-1         Up X minutes   127.0.0.1:5001->5001/tcp
+csd-demo-2         Up X minutes   127.0.0.1:5002->5001/tcp
+csd-demo-3         Up X minutes   127.0.0.1:5003->5001/tcp
+csd-demo-4         Up X minutes   127.0.0.1:5004->5001/tcp
+dvga-1             Up X minutes   127.0.0.1:5201->5013/tcp
+dvga-2             Up X minutes   127.0.0.1:5202->5013/tcp
+dvga-3             Up X minutes   127.0.0.1:5203->5013/tcp
+dvga-4             Up X minutes   127.0.0.1:5204->5013/tcp
+dvwa-1             Up X minutes   127.0.0.1:8101->80/tcp
+dvwa-2             Up X minutes   127.0.0.1:8102->80/tcp
+dvwa-3             Up X minutes   127.0.0.1:8103->80/tcp
+dvwa-4             Up X minutes   127.0.0.1:8104->80/tcp
+dvwa-db            Up X minutes   3306/tcp
+httpbin-1          Up X minutes   127.0.0.1:8201->80/tcp
+httpbin-2          Up X minutes   127.0.0.1:8202->80/tcp
+httpbin-3          Up X minutes   127.0.0.1:8203->80/tcp
+httpbin-4          Up X minutes   127.0.0.1:8204->80/tcp
+juice-shop-1       Up X minutes   127.0.0.1:3001->3000/tcp
+juice-shop-2       Up X minutes   127.0.0.1:3002->3000/tcp
+juice-shop-3       Up X minutes   127.0.0.1:3003->3000/tcp
+juice-shop-4       Up X minutes   127.0.0.1:3004->3000/tcp
+restaurant-1       Up X minutes   127.0.0.1:8301->8080/tcp
+restaurant-2       Up X minutes   127.0.0.1:8302->8080/tcp
+restaurant-3       Up X minutes   127.0.0.1:8303->8080/tcp
+restaurant-4       Up X minutes   127.0.0.1:8304->8080/tcp
+restaurant-db      Up X minutes   5432/tcp
+vampi-1            Up X minutes   127.0.0.1:5101->5000/tcp
+vampi-2            Up X minutes   127.0.0.1:5102->5000/tcp
+vampi-3            Up X minutes   127.0.0.1:5103->5000/tcp
+vampi-4            Up X minutes   127.0.0.1:5104->5000/tcp
+whoami-1           Up X minutes   127.0.0.1:8082->80/tcp
+whoami-2           Up X minutes   127.0.0.1:8083->80/tcp
+whoami-3           Up X minutes   127.0.0.1:8084->80/tcp
+whoami-4           Up X minutes   127.0.0.1:8085->80/tcp
 ```
 
 ### nginx Status
@@ -135,6 +160,9 @@ ssh azureuser@${ORIGIN_IP} "sudo docker logs dvwa-1 2>&1 | tail -20"
 ssh azureuser@${ORIGIN_IP} "sudo docker logs vampi-1 2>&1 | tail -20"
 ssh azureuser@${ORIGIN_IP} "sudo docker logs httpbin-1 2>&1 | tail -20"
 ssh azureuser@${ORIGIN_IP} "sudo docker logs csd-demo-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs dvga-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs restaurant-1 2>&1 | tail -20"
+ssh azureuser@${ORIGIN_IP} "sudo docker logs crapi-web 2>&1 | tail -20"
 ```
 
 ### nginx returning 502

--- a/docs/06-integrate.mdx
+++ b/docs/06-integrate.mdx
@@ -50,6 +50,8 @@ Each application is accessible via its path prefix through the load balancer:
 | `https://demo.example.com/httpbin/` | `/httpbin/` | httpbin (4 instances, round-robin) |
 | `https://demo.example.com/whoami/` | `/whoami/` | Request diagnostics (4 instances) |
 | `https://demo.example.com/csd-demo/` | `/csd-demo/` | CSD Demo (4 instances, ip_hash sticky) |
+| `https://demo.example.com/dvga/` | `/dvga/` | DVGA (4 instances, ip_hash sticky) |
+| `https://demo.example.com/restaurant/` | `/restaurant/` | RESTaurant (4 instances, round-robin) |
 | `https://demo.example.com/health` | `/health` | Health check (nginx direct) |
 
 ### Verify F5 XC Header Injection
@@ -108,6 +110,32 @@ curl -sk -X POST "https://${LB_DOMAIN}/vampi/users/v1/login" \
   -d '{"username":"apitest","password":"test123"}'
 ```
 
+### crAPI Integration (Port 8888)
+
+crAPI runs on a dedicated port (8888) because it is a single-page application that hardcodes its API paths and cannot be served behind a path prefix. To integrate crAPI with F5 XC:
+
+| Setting | Value |
+|---|---|
+| **Origin Server Type** | Public IP of Origin Server |
+| **IP Address** | `<terraform output public_ip>` |
+| **Port** | `8888` |
+| **Health Check** | HTTP, path `/` |
+
+Create a **separate origin pool** for crAPI on port 8888, or add a second origin pool member to your existing pool with port 8888 and use route rules to direct traffic:
+
+```bash
+# Test crAPI through F5 XC (if configured)
+curl -sk "https://${LB_DOMAIN}:8888/"
+
+# Or if using route rules on the same LB domain:
+# Configure an F5 XC route rule matching Host header or path prefix
+# to forward to the crAPI origin pool (port 8888)
+```
+
+:::note
+The NSG on the origin VM allows inbound traffic on port 8888. No additional Azure network changes are needed.
+:::
+
 ### Sticky Session Awareness
 
 The origin server uses nginx sticky sessions internally to route stateful applications to consistent backend containers. When configuring the F5 XC HTTP load balancer, be aware:
@@ -118,6 +146,9 @@ The origin server uses nginx sticky sessions internally to route stateful applic
 | DVWA | `hash $cookie_PHPSESSID` | PHP session state |
 | VAmPI | `ip_hash` | SQLite database per instance |
 | CSD Demo | `ip_hash` | In-memory exfil log per instance |
+| DVGA | `ip_hash` | SQLite database per instance |
+| RESTaurant | Round-robin | Shared PostgreSQL backend |
+| crAPI | -- (single port 8888) | 7 microservices, PostgreSQL + MongoDB |
 | httpbin | Round-robin | Stateless |
 | whoami | Round-robin | Stateless |
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Origin Server
-description: "Ubuntu 24.04 Azure VM running nginx reverse proxy to Docker containers: Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo for WAF, API security, bot defense, and client-side defense testing with F5 Distributed Cloud"
+description: "Ubuntu 24.04 Azure VM running nginx reverse proxy to Docker containers: Juice Shop, DVWA, VAmPI, httpbin, whoami, CSD Demo, DVGA, RESTaurant, and crAPI for WAF, API security, bot defense, and client-side defense testing with F5 Distributed Cloud"
 template: splash
 sidebar:
   hidden: true
@@ -27,7 +27,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     title="Multi-App Origin"
-    description="One Ubuntu 24.04 VM (16 vCPU, 64 GiB) running nginx as a reverse proxy to 25 Docker containers: Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo — each scaled to 4 load-balanced instances."
+    description="One Ubuntu 24.04 VM (16 vCPU, 64 GiB) running nginx as a reverse proxy to 41 Docker containers: Juice Shop, DVWA, VAmPI, httpbin, whoami, CSD Demo, DVGA, RESTaurant, and crAPI."
     href="01-architecture/"
   />
   <LinkCard
@@ -37,7 +37,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     title="Vulnerable Applications"
-    description="Juice Shop, DVWA, VAmPI, httpbin, whoami, and CSD Demo covering WAF, API security, bot defense, client-side defense, and request diagnostics."
+    description="Juice Shop, DVWA, VAmPI, httpbin, whoami, CSD Demo, DVGA, RESTaurant, and crAPI covering WAF, API security, bot defense, client-side defense, GraphQL security, and request diagnostics."
     href="04-applications/"
   />
   <LinkCard

--- a/manifest.json
+++ b/manifest.json
@@ -143,6 +143,74 @@
       },
       "credentials": null,
       "demo_features": ["client-side-defense"]
+    },
+    {
+      "name": "dvga",
+      "path": "/dvga/",
+      "description": "DVGA — Damn Vulnerable GraphQL Application with 20+ vulnerability scenarios",
+      "container": {
+        "image": "dolevf/dvga",
+        "tag": "latest",
+        "internal_port": 5013,
+        "instances": 4,
+        "host_ports": "5201-5204",
+        "sticky": "ip_hash",
+        "resources": "0.5 CPU / 256M"
+      },
+      "health_check": {
+        "path": "/dvga/",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["api-security", "graphql"]
+    },
+    {
+      "name": "restaurant",
+      "path": "/restaurant/",
+      "description": "Damn Vulnerable RESTaurant — FastAPI game covering OWASP API Security Top 10 2023",
+      "container": {
+        "image": "restaurant-api",
+        "tag": "latest",
+        "build": true,
+        "internal_port": 8091,
+        "instances": 4,
+        "host_ports": "8301-8304",
+        "entrypoint": "uvicorn --root-path /restaurant",
+        "resources": "0.5 CPU / 256M",
+        "database": "postgres:15.4-alpine (restaurant-db, 0.5 CPU / 512M)"
+      },
+      "health_check": {
+        "path": "/restaurant/docs",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": {
+        "username": "admin",
+        "password": "password"
+      },
+      "demo_features": ["api-security"]
+    },
+    {
+      "name": "crapi",
+      "path": ":8888",
+      "description": "crAPI — OWASP microservices API with BOLA, BFLA, mass assignment, and SSRF challenges",
+      "container": {
+        "image": "crapi/*",
+        "tag": "latest",
+        "internal_port": 80,
+        "instances": 1,
+        "host_ports": "18888",
+        "resources": "3.0 CPU / 2048M total (7 microservices)",
+        "database": "postgres:14 + mongo:4.4"
+      },
+      "health_check": {
+        "path": ":8888/health",
+        "method": "GET",
+        "expected_status": 200
+      },
+      "credentials": null,
+      "demo_features": ["api-security", "bola", "bfla", "mass-assignment", "ssrf"]
     }
   ]
 }

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -180,7 +180,46 @@ check_contains "csd-demo-exfil-receives" '"received"' "$CSD_EXFIL"
 CSD_LOG=$(curl -sf --max-time 5 "${BASE}/csd-demo/exfil/log" 2>/dev/null || echo "[]")
 check_contains "csd-demo-exfil-log-has-entry" "smoke-test" "$CSD_LOG"
 
-# ── 8. Cross-cutting ───────────────────────────────
+# ── 8. DVGA ───────────────────────────────────────
+
+echo "── DVGA (GraphQL) ──"
+
+DVGA_HOME=$(curl -sf --max-time 10 -o /dev/null -w "%{http_code}" "${BASE}/dvga/" 2>/dev/null || echo "000")
+check "dvga-home-200" "200" "$DVGA_HOME"
+
+DVGA_GQL=$(curl -sf --max-time 10 -X POST "${BASE}/dvga/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{__schema{queryType{name}}}"}' 2>/dev/null || echo "{}")
+check_contains "dvga-graphql-introspection" '"Query"' "$DVGA_GQL"
+
+# ── 9. RESTaurant API ────────────────────────────────
+
+echo "── RESTaurant API ──"
+
+REST_DOCS=$(curl -sf --max-time 10 -o /dev/null -w "%{http_code}" "${BASE}/restaurant/docs" 2>/dev/null || echo "000")
+check "restaurant-docs-200" "200" "$REST_DOCS"
+
+REST_OPENAPI=$(curl -sf --max-time 10 "${BASE}/restaurant/openapi.json" 2>/dev/null || echo "{}")
+check_contains "restaurant-openapi-title" '"Damn Vulnerable RESTaurant"' "$REST_OPENAPI"
+
+# ── 10. crAPI ─────────────────────────────────────────
+
+echo "── crAPI (port 8888) ──"
+
+CRAPI_BASE="http://${ORIGIN_IP}:8888"
+
+CRAPI_HOME=$(curl -sf --max-time 10 -o /dev/null -w "%{http_code}" "${CRAPI_BASE}/" 2>/dev/null || echo "000")
+check "crapi-home-200" "200" "$CRAPI_HOME"
+
+CRAPI_HEALTH=$(curl -sf --max-time 10 "${CRAPI_BASE}/health" 2>/dev/null || echo "")
+check_contains "crapi-health-ok" "OK" "$CRAPI_HEALTH"
+
+CRAPI_SIGNUP=$(curl -sf --max-time 15 -X POST "${CRAPI_BASE}/identity/api/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Smoke Test","email":"smoke@example.com","number":"5551234567","password":"SmokeTest123"}' 2>/dev/null || echo "{}")
+check_contains "crapi-signup-responds" '"message"' "$CRAPI_SIGNUP"
+
+# ── 11. Cross-cutting ───────────────────────────────
 
 echo "── Cross-cutting ──"
 


### PR DESCRIPTION
## Summary

- Add three new API security testing applications: DVGA (GraphQL vulnerabilities), RESTaurant API (OWASP API Top 10 2023), and crAPI (BOLA, BFLA, mass assignment, SSRF, JWT)
- DVGA and RESTaurant run as 4 load-balanced instances each behind nginx; crAPI runs as 7 microservices on dedicated port 8888
- Update all documentation pages, manifest.json, and smoke tests to cover new endpoints

Closes #46

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Smoke tests pass for DVGA endpoint (/dvga/)
- [ ] Smoke tests pass for RESTaurant endpoint (/restaurant/)
- [ ] Smoke tests pass for crAPI endpoint (port 8888)
- [ ] All 41 containers verified running on live server