### PR TITLE
fix: bump crapi-identity to 768M and crapi-mongo to 256M to prevent OOM

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1045,7 +1045,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.8"
-                memory: 512M
+                memory: 768M
 
         crapi-community:
           image: crapi/crapi-community:latest
@@ -1164,7 +1164,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.3"
-                memory: 128M
+                memory: 256M
 
         crapi-mailhog:
           image: crapi/mailhog:latest


### PR DESCRIPTION
## Summary

- Bump crapi-identity (Java Spring Boot) memory limit from 512M to 768M — was at 94.5% utilization at idle with upward drift
- Bump crapi-mongo memory limit from 128M to 256M — hit 87.5% during traffic tests

Both services verified healthy on live server after the bump.

Closes #48

## Test plan

- [ ] CI checks pass
- [ ] crapi-identity container stays healthy under load without OOM
- [ ] crapi-mongo container stays healthy during traffic tests without OOM