### PR TITLE
perf: fix RESTaurant memory leak — add uvicorn worker recycling and bump to 384M

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -875,7 +875,7 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8301:8091"
-          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant --limit-max-requests 200"]
           environment:
             - POSTGRES_USER=admin
             - POSTGRES_PASSWORD=password
@@ -891,7 +891,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         restaurant-2:
           build: ./restaurant/
@@ -899,7 +899,7 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8302:8091"
-          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant --limit-max-requests 200"]
           environment:
             - POSTGRES_USER=admin
             - POSTGRES_PASSWORD=password
@@ -915,7 +915,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         restaurant-3:
           build: ./restaurant/
@@ -923,7 +923,7 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8303:8091"
-          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant --limit-max-requests 200"]
           environment:
             - POSTGRES_USER=admin
             - POSTGRES_PASSWORD=password
@@ -939,7 +939,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         restaurant-4:
           build: ./restaurant/
@@ -947,7 +947,7 @@ write_files:
           restart: unless-stopped
           ports:
             - "127.0.0.1:8304:8091"
-          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant"]
+          command: ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8091 --root-path /restaurant --limit-max-requests 200"]
           environment:
             - POSTGRES_USER=admin
             - POSTGRES_PASSWORD=password
@@ -963,7 +963,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         crapi-web:
           image: crapi/crapi-web:latest


### PR DESCRIPTION
## Summary

- Added `--limit-max-requests 200` to uvicorn command to force worker restart after 200 requests, preventing memory accumulation from Python memory fragmentation
- Bumped RESTaurant container memory limit from 256M to 384M to provide headroom during the recycling window
- Same leak pattern as DVWA PHP-FPM — unbounded worker lifetime causes monotonic memory growth under sustained traffic

Closes #58

## Test plan

- [ ] CI checks pass
- [ ] Verify uvicorn command includes `--limit-max-requests 200` in cloud-init template
- [ ] Verify memory limit is 384M for RESTaurant containers
- [ ] Confirm container memory usage stabilizes under sustained load after deploy