### PR TITLE
perf: bump DVGA memory to 384M and crAPI workshop to 4 workers / 1.0 CPU

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -803,7 +803,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         dvga-2:
           image: dolevf/dvga:latest
@@ -817,7 +817,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         dvga-3:
           image: dolevf/dvga:latest
@@ -831,7 +831,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         dvga-4:
           image: dolevf/dvga:latest
@@ -845,7 +845,7 @@ write_files:
             resources:
               limits:
                 cpus: "0.5"
-                memory: 256M
+                memory: 384M
 
         restaurant-db:
           image: postgres:15.4-alpine
@@ -1104,7 +1104,7 @@ write_files:
             - API_GATEWAY_URL=https://api.mypremiumdealership.com
             - TLS_ENABLED=false
             - FILES_LIMIT=1000
-            - GUNICORN_WORKERS=2
+            - GUNICORN_WORKERS=4
           depends_on:
             crapi-postgres:
               condition: service_healthy
@@ -1122,7 +1122,7 @@ write_files:
           deploy:
             resources:
               limits:
-                cpus: "0.5"
+                cpus: "1.0"
                 memory: 512M
 
         crapi-postgres:


### PR DESCRIPTION
## Summary

Two optimizations from sustained torture testing:

1. **DVGA (4 instances):** memory 256M to 384M — SQLite database growth under sustained GraphQL mutation traffic caused dvga-2 to hit 94.5% and OOM. Larger limit accommodates database growth.
2. **crAPI workshop:** GUNICORN_WORKERS 2 to 4, CPU 0.5 to 1.0 — was the slowest API endpoint (25 req/s, 6.3s latency). Now fully utilizes 1.0 CPU under load, confirming the upgrade is effective.

Closes #60

## Test plan

- [ ] CI checks pass
- [ ] Verify DVGA instances remain stable under sustained GraphQL mutation load
- [ ] Verify crAPI workshop latency improves under concurrent traffic