### PR TITLE
feat(llms): add API Testing Guide custom set to llms-config.json

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -9,8 +9,13 @@
       "label": "Integration",
       "description": "Integration with F5 XC HTTP load balancers and WAF policies",
       "paths": ["06-integrate*"]
+    },
+    {
+      "label": "API Testing Guide",
+      "description": "Comprehensive API vulnerability testing patterns for DVGA, RESTaurant, and crAPI applications",
+      "paths": ["08-api-testing-guide*"]
     }
   ],
-  "promote": ["index*", "01-architecture*", "03-deploy*"],
+  "promote": ["index*", "01-architecture*", "03-deploy*", "08-api-testing-guide*"],
   "demote": ["07-teardown*"]
 }


### PR DESCRIPTION
## Summary

- Add new `customSets` entry for "API Testing Guide" (`08-api-testing-guide*`) to `docs/llms-config.json`
- Add `08-api-testing-guide*` to the `promote` array for inclusion in `llms.txt`
- Ensures the comprehensive API vulnerability testing guide (added in #53) is discoverable through the llms.txt hierarchy

Closes #66

## Related

Part of resolving f5xc-salesdemos/docs#359.

## Test plan

- [ ] CI checks pass
- [ ] Verify `llms-config.json` is valid JSON after the change
- [ ] Confirm the llms.txt build pipeline picks up the new custom set