### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+ignore-words-list = afterall,aks,anull,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.11
 ignore_missing_imports = True
+exclude = (?x)(\.mdx$)
 check_untyped_defs = True
 warn_return_any = False
 disallow_untyped_defs = False

--- a/.python-lint
+++ b/.python-lint
@@ -1,6 +1,7 @@
 [MAIN]
 py-version = 3.11
 jobs = 0
+ignore-paths = ^.*\.mdx$
 
 [FORMAT]
 max-line-length = 88

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,6 @@
 line-length = 88
 target-version = "py313"
+extend-exclude = ["*.mdx"]
 
 [format]
 quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,6 @@
 line-length = 88
 target-version = "py313"
+extend-exclude = ["*.mdx"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
Closes #68

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- README.md
- .codespellrc
- .ruff.toml
- ruff.toml
- .python-lint
- .mypy.ini