### PR TITLE
fix: correct crAPI manifest path to pass validation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -193,7 +193,8 @@
     },
     {
       "name": "crapi",
-      "path": ":8888",
+      "port": 8888,
+      "path": "/",
       "description": "crAPI — OWASP microservices API with BOLA, BFLA, mass assignment, and SSRF challenges",
       "container": {
         "image": "crapi/*",
@@ -205,7 +206,7 @@
         "database": "postgres:14 + mongo:4.4"
       },
       "health_check": {
-        "path": ":8888/health",
+        "path": "/health",
         "method": "GET",
         "expected_status": 200
       },


### PR DESCRIPTION
## Summary

- Correct crAPI `path` from `":8888"` to `"/"` and `health_check.path` from `":8888/health"` to `"/health"` so the manifest validator accepts them
- Add `"port": 8888` field to preserve the dedicated-port metadata
- All 22 manifest validation checks pass locally

Closes #72

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] `validate-manifest.js` passes all 22 checks
- [ ] crAPI health check path resolves correctly at runtime