### PR TITLE
feat: add component manifest for progressive discovery

### DIFF
--- a/component-manifest.json
+++ b/component-manifest.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1",
+  "name": "origin-server",
+  "role": "Origin server with vulnerable web applications",
+  "category": "lab-infrastructure",
+  "summary": "Ubuntu 24.04 Azure VM running nginx reverse proxy to 41 Docker containers across 9 vulnerable applications for WAF, API security, bot defense, and client-side defense testing with F5 Distributed Cloud",
+  "provides": [
+    "vulnerable-web-apps",
+    "waf-target",
+    "api-security-target",
+    "bot-defense-target",
+    "client-side-defense-target"
+  ],
+  "pairs_with": ["traffic-generator", "cdn-simulator"],
+  "demos": ["waf", "api-security", "bot-standard", "bot-advanced", "csd", "was"],
+  "terraform": {
+    "required_vars": ["subscription_id"],
+    "vm_size": "Standard_D16s_v3",
+    "estimated_monthly_cost": "$486"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `component-manifest.json` declaring the origin-server's role, category, capabilities, terraform requirements, and compatible demos
- Enables xcsh to dynamically discover and surface this component when sales engineers build demo architectures
- Schema version 1 format with all required fields for the progressive component discovery feature

Closes #78

## Test plan

- [ ] CI checks pass (lint, JSON validation)
- [ ] `component-manifest.json` is valid JSON with all required fields
- [ ] No existing files are modified