### PR TITLE
feat: auto-generate unique Azure resource names with random_pet suffix

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,10 +6,22 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
   subscription_id = var.subscription_id
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}
+
+locals {
+  suffix = random_pet.suffix.id
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "origin" {
-  name     = var.resource_group_name
+  name     = "${var.resource_group_name}-${local.suffix}"
   location = var.location
 
   tags = {
@@ -9,7 +9,7 @@ resource "azurerm_resource_group" "origin" {
 }
 
 resource "azurerm_virtual_network" "origin" {
-  name                = "vnet-origin-server"
+  name                = "vnet-origin-${local.suffix}"
   address_space       = ["10.200.0.0/16"]
   location            = azurerm_resource_group.origin.location
   resource_group_name = azurerm_resource_group.origin.name
@@ -26,7 +26,7 @@ resource "azurerm_subnet" "origin" {
 }
 
 resource "azurerm_public_ip" "origin" {
-  name                = "pip-origin-server"
+  name                = "pip-origin-${local.suffix}"
   location            = azurerm_resource_group.origin.location
   resource_group_name = azurerm_resource_group.origin.name
   allocation_method   = "Static"
@@ -39,7 +39,7 @@ resource "azurerm_network_security_group" "origin" {
   #checkov:skip=CKV_AZURE_10:Lab NSG - SSH open for demo access
   #checkov:skip=CKV_AZURE_160:Lab NSG - HTTP port 80 required for traffic
   #checkov:skip=CKV_AZURE_220:Lab NSG - SSH open for demo access
-  name                = "nsg-origin-server"
+  name                = "nsg-origin-${local.suffix}"
   location            = azurerm_resource_group.origin.location
   resource_group_name = azurerm_resource_group.origin.name
 
@@ -96,7 +96,7 @@ resource "azurerm_network_security_group" "origin" {
 
 resource "azurerm_network_interface" "origin" {
   #checkov:skip=CKV_AZURE_119:Lab NIC - public IP required for demo access
-  name                = "nic-origin-server"
+  name                = "nic-origin-${local.suffix}"
   location            = azurerm_resource_group.origin.location
   resource_group_name = azurerm_resource_group.origin.name
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -62,3 +62,8 @@ output "resource_group" {
   description = "Resource group containing all origin server resources"
   value       = azurerm_resource_group.origin.name
 }
+
+output "deployment_suffix" {
+  description = "Unique deployment suffix for this instance"
+  value       = local.suffix
+}

--- a/terraform/vm.tf
+++ b/terraform/vm.tf
@@ -1,7 +1,7 @@
 resource "azurerm_linux_virtual_machine" "origin" {
   #checkov:skip=CKV_AZURE_50:Lab VM - no extensions required
   #checkov:skip=CKV_AZURE_93:Lab VM - platform-managed encryption sufficient
-  name                = "vm-origin-server"
+  name                = "vm-origin-${local.suffix}"
   resource_group_name = azurerm_resource_group.origin.name
   location            = azurerm_resource_group.origin.location
   size                = var.vm_size


### PR DESCRIPTION
## Summary

- Add `random_pet` provider to generate a unique two-word suffix (e.g. "happy-panda") per deployment
- Apply suffix to all top-level Azure resource names (resource group, VNet, public IP, NSG, NIC, VM) to prevent naming collisions when multiple sales engineers deploy into the same subscription
- Suffix is generated once and stored in Terraform state — stable across plan/apply cycles with no user input required
- Add `deployment_suffix` output for easy reference

Closes #82

## Test plan

- [ ] CI checks pass
- [ ] `terraform init` succeeds with new `random` provider
- [ ] `terraform plan` shows suffixed resource names
- [ ] Two separate `terraform init`/`plan` runs produce different suffixes
- [ ] Existing deployments can `terraform plan` without forced replacement (suffix stored in state)