### PR TITLE
feat(terraform): standardize terraform per Demo Resource Standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,20 @@ repos:
         args: ["--branch", "main"]
 
   # ===========================================================================
+  # Terraform formatting and validation
+  # ===========================================================================
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--add-to-existing-file=true
+          - --args=--config=.terraform-docs.yml
+
+  # ===========================================================================
   # Repository-specific hooks (escape hatch)
   #
   # Runs scripts/pre-commit-local.sh if present and executable. Repos use
@@ -204,3 +218,6 @@ ci:
     - zizmor
     - checkov
     - gitleaks
+    - terraform_fmt
+    - terraform_validate
+    - terraform_docs

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,19 @@
+formatter: markdown table
+
+content: ""
+
+output:
+  file: ../README.md
+  mode: inject
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: true
+  escape: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,88 @@ and usage guides.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow rules,
 branch naming, and CI requirements.
 
+## Terraform Reference
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.71.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_linux_virtual_machine.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) | resource |
+| [azurerm_network_interface.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_user.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID | `string` | n/a | yes |
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | SSH admin username for the VM | `string` | `"azureuser"` | no |
+| <a name="input_deployer"></a> [deployer](#input\_deployer) | Override for deployer identifier (auto-resolved from Azure AD if empty). Required for service principal or managed identity authentication. | `string` | `""` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | OS disk size in GB | `number` | `60` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment label used in resource group naming and tags | `string` | `"lab"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for all resources | `string` | `"eastus2"` | no |
+| <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Path to the SSH public key file | `string` | `"~/.ssh/id_ed25519.pub"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags merged with standard tags (component, environment, deployer, managed\_by) | `map(string)` | `{}` | no |
+| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | Azure VM size (Standard\_D16s\_v3: 16 vCPU, 64 GiB RAM for Docker workloads) | `string` | `"Standard_D16s_v3"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_component"></a> [component](#output\_component) | Component name |
+| <a name="output_crapi_url"></a> [crapi\_url](#output\_crapi\_url) | crAPI microservices security URL |
+| <a name="output_deployer"></a> [deployer](#output\_deployer) | Resolved deployer identifier |
+| <a name="output_dvga_url"></a> [dvga\_url](#output\_dvga\_url) | DVGA GraphQL security URL |
+| <a name="output_dvwa_url"></a> [dvwa\_url](#output\_dvwa\_url) | DVWA URL |
+| <a name="output_environment"></a> [environment](#output\_environment) | Environment label |
+| <a name="output_health_check_url"></a> [health\_check\_url](#output\_health\_check\_url) | Health check endpoint |
+| <a name="output_httpbin_url"></a> [httpbin\_url](#output\_httpbin\_url) | httpbin URL |
+| <a name="output_juice_shop_url"></a> [juice\_shop\_url](#output\_juice\_shop\_url) | OWASP Juice Shop URL |
+| <a name="output_location"></a> [location](#output\_location) | Azure region |
+| <a name="output_nsg_id"></a> [nsg\_id](#output\_nsg\_id) | Resource ID of the network security group |
+| <a name="output_nsg_name"></a> [nsg\_name](#output\_nsg\_name) | Name of the network security group |
+| <a name="output_origin_url"></a> [origin\_url](#output\_origin\_url) | Base HTTP URL of the origin server |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP address of the VM |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | Public IP address of the VM |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | Resource ID of the resource group |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Name of the resource group |
+| <a name="output_restaurant_url"></a> [restaurant\_url](#output\_restaurant\_url) | RESTaurant API security URL |
+| <a name="output_ssh_command"></a> [ssh\_command](#output\_ssh\_command) | SSH command to connect to the VM |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | Resource ID of the subnet |
+| <a name="output_vampi_url"></a> [vampi\_url](#output\_vampi\_url) | VAmPI URL |
+| <a name="output_vm_id"></a> [vm\_id](#output\_vm\_id) | Resource ID of the virtual machine |
+| <a name="output_vm_name"></a> [vm\_name](#output\_vm\_name) | Name of the virtual machine |
+| <a name="output_vnet_name"></a> [vnet\_name](#output\_vnet\_name) | Name of the virtual network |
+| <a name="output_whoami_url"></a> [whoami\_url](#output\_whoami\_url) | whoami request diagnostics URL |
+<!-- END_TF_DOCS -->
+
 ## License
 
 See [LICENSE](LICENSE).

--- a/component-manifest.json
+++ b/component-manifest.json
@@ -1,9 +1,11 @@
 {
-  "schema_version": "1",
+  "schema_version": "2",
   "name": "origin-server",
+  "display_name": "Origin Server",
   "role": "Origin server with vulnerable web applications",
   "category": "lab-infrastructure",
   "summary": "Ubuntu 24.04 Azure VM running nginx reverse proxy to 41 Docker containers across 9 vulnerable applications for WAF, API security, bot defense, and client-side defense testing with F5 Distributed Cloud",
+
   "provides": [
     "vulnerable-web-apps",
     "waf-target",
@@ -13,9 +15,140 @@
   ],
   "pairs_with": ["traffic-generator", "cdn-simulator"],
   "demos": ["waf", "api-security", "bot-standard", "bot-advanced", "csd", "was"],
+
   "terraform": {
-    "required_vars": ["subscription_id"],
-    "vm_size": "Standard_D16s_v3",
-    "estimated_monthly_cost": "$486"
+    "required_inputs": {
+      "subscription_id": {
+        "type": "string",
+        "description": "Azure subscription ID"
+      }
+    },
+    "optional_inputs": {
+      "deployer": {
+        "type": "string",
+        "default": "",
+        "description": "Override for deployer identifier (auto-resolved from Azure AD if empty)"
+      },
+      "location": {
+        "type": "string",
+        "default": "eastus2",
+        "description": "Azure region for all resources"
+      },
+      "environment": {
+        "type": "string",
+        "default": "lab",
+        "description": "Environment label used in resource group naming and tags"
+      },
+      "vm_size": {
+        "type": "string",
+        "default": "Standard_D16s_v3",
+        "description": "Azure VM size (16 vCPU, 64 GiB RAM for Docker workloads)"
+      },
+      "disk_size_gb": {
+        "type": "number",
+        "default": 60,
+        "description": "OS disk size in GB"
+      },
+      "admin_username": {
+        "type": "string",
+        "default": "azureuser",
+        "description": "SSH admin username for the VM"
+      },
+      "ssh_public_key_path": {
+        "type": "string",
+        "default": "~/.ssh/id_ed25519.pub",
+        "description": "Path to the SSH public key file"
+      },
+      "tags": {
+        "type": "map(string)",
+        "default": {},
+        "description": "Additional tags merged with standard tags"
+      }
+    },
+    "standard_outputs": [
+      "deployer",
+      "resource_group_name",
+      "resource_group_id",
+      "location",
+      "public_ip",
+      "private_ip",
+      "ssh_command",
+      "vm_name",
+      "vm_id",
+      "nsg_name",
+      "nsg_id",
+      "vnet_name",
+      "subnet_id",
+      "component",
+      "environment"
+    ],
+    "component_outputs": {
+      "origin_url": { "type": "string", "description": "Base HTTP URL of the origin server" },
+      "health_check_url": { "type": "string", "description": "Health check endpoint" },
+      "juice_shop_url": { "type": "string", "description": "OWASP Juice Shop URL" },
+      "dvwa_url": { "type": "string", "description": "DVWA URL" },
+      "vampi_url": { "type": "string", "description": "VAmPI URL" },
+      "httpbin_url": { "type": "string", "description": "httpbin URL" },
+      "whoami_url": { "type": "string", "description": "whoami request diagnostics URL" },
+      "dvga_url": { "type": "string", "description": "DVGA GraphQL security URL" },
+      "restaurant_url": { "type": "string", "description": "RESTaurant API security URL" },
+      "crapi_url": { "type": "string", "description": "crAPI microservices security URL" }
+    },
+    "estimated_monthly_cost": "$486",
+    "vm_image": {
+      "publisher": "Canonical",
+      "offer": "ubuntu-24_04-lts",
+      "sku": "server",
+      "version": "latest"
+    }
+  },
+
+  "nsg_rules": [
+    {
+      "name": "AllowHTTP",
+      "priority": 100,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "80",
+      "source_address_prefix": "*",
+      "description": "HTTP traffic for web applications"
+    },
+    {
+      "name": "AllowHTTPS",
+      "priority": 110,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "443",
+      "source_address_prefix": "*",
+      "description": "HTTPS traffic for web applications"
+    },
+    {
+      "name": "AllowSSH",
+      "priority": 120,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "22",
+      "source_address_prefix": "*",
+      "description": "SSH access for administration"
+    },
+    {
+      "name": "AllowCrAPI",
+      "priority": 130,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "8888",
+      "source_address_prefix": "*",
+      "description": "crAPI microservices port"
+    }
+  ],
+
+  "health_check": {
+    "path": "/health",
+    "port": 80,
+    "expected_status": 200
   }
 }

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,19 +1,19 @@
 {
   "customSets": [
     {
-      "label": "Deployment Guide",
-      "description": "Step-by-step deployment from architecture through teardown",
-      "paths": ["01-architecture*", "02-prerequisites*", "03-deploy*", "04-applications*", "05-verify*"]
+      "label": "Deployment",
+      "description": "Terraform IaC deployment with prerequisites and teardown",
+      "paths": ["02-prerequisites*", "03-deploy*", "07-teardown*"]
+    },
+    {
+      "label": "Applications",
+      "description": "Vulnerable web application architecture, configuration, and API testing",
+      "paths": ["01-architecture*", "04-applications*", "05-verify*", "08-api-testing-guide*"]
     },
     {
       "label": "Integration",
       "description": "Integration with F5 XC HTTP load balancers and WAF policies",
       "paths": ["06-integrate*"]
-    },
-    {
-      "label": "API Testing Guide",
-      "description": "Comprehensive API vulnerability testing patterns for DVGA, RESTaurant, and crAPI applications",
-      "paths": ["08-api-testing-guide*"]
     }
   ],
   "promote": ["index*", "01-architecture*", "03-deploy*", "08-api-testing-guide*"],

--- a/terraform/cloud-init.yaml
+++ b/terraform/cloud-init.yaml
@@ -1747,5 +1747,5 @@ runcmd:
     done
   - |
     TOKEN=$(curl -sf http://127.0.0.1:8101/setup.php | grep -oP "user_token.*?value='\K[a-f0-9]+" | head -1)
-    curl -sf -X POST http://127.0.0.1:8101/setup.php -d "create_db=Create+%2F+Reset+Database&user_token=${TOKEN}" -c /tmp/dvwa-setup -b /tmp/dvwa-setup
+    curl -sf -X POST http://127.0.0.1:8101/setup.php -d "create_db=Create+%2F+Reset+Database&user_token=$${TOKEN}" -c /tmp/dvwa-setup -b /tmp/dvwa-setup
   - systemctl restart nginx

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,6 @@
+data "azuread_client_config" "current" {}
+
+data "azuread_user" "current" {
+  count     = var.deployer == "" ? 1 : 0
+  object_id = data.azuread_client_config.current.object_id
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,58 @@
+locals {
+  component = "origin-server"
+
+  # --- Deployer resolution (4-tier fallback) ---
+  # 1. Explicit override via var.deployer
+  # 2a. Azure AD: given_name initial + surname
+  # 2b. Azure AD: mail prefix (guest/external accounts)
+  # 3. Object ID hash (service principals, managed identities)
+  deployer_from_name = (
+    var.deployer == "" && length(data.azuread_user.current) > 0
+    ? try(
+      lower("${substr(data.azuread_user.current[0].given_name, 0, 1)}${data.azuread_user.current[0].surname}"),
+      ""
+    )
+    : ""
+  )
+
+  deployer_from_mail = (
+    var.deployer == "" && length(data.azuread_user.current) > 0 && local.deployer_from_name == ""
+    ? try(
+      lower(split("@", data.azuread_user.current[0].mail)[0]),
+      ""
+    )
+    : ""
+  )
+
+  deployer_from_oid = substr(sha1(data.azuread_client_config.current.object_id), 0, 8)
+
+  deployer_resolved = coalesce(
+    var.deployer,
+    local.deployer_from_name,
+    local.deployer_from_mail,
+    local.deployer_from_oid
+  )
+
+  deployer = replace(lower(local.deployer_resolved), "/[^a-z0-9]/", "")
+
+  # --- Resource naming (Cloud Adoption Framework) ---
+  name = {
+    resource_group    = "rg-${local.component}-${var.environment}-${local.deployer}"
+    virtual_network   = "vnet-${local.component}-${local.deployer}"
+    subnet            = "snet-${local.component}-${local.deployer}"
+    public_ip         = "pip-${local.component}-${local.deployer}"
+    nsg               = "nsg-${local.component}-${local.deployer}"
+    network_interface = "nic-${local.component}-${local.deployer}"
+    virtual_machine   = "vm-${local.component}-${local.deployer}"
+  }
+
+  # --- Standard tags ---
+  standard_tags = {
+    component   = local.component
+    environment = var.environment
+    deployer    = local.deployer
+    managed_by  = "terraform"
+  }
+
+  tags = merge(local.standard_tags, var.tags)
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,27 +1,5 @@
-terraform {
-  required_version = ">= 1.5.0"
-
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
-  }
-}
-
-provider "azurerm" {
-  features {}
-  subscription_id = var.subscription_id
-}
-
-resource "random_pet" "suffix" {
-  length = 2
-}
-
-locals {
-  suffix = random_pet.suffix.id
+resource "azurerm_resource_group" "main" {
+  name     = local.name.resource_group
+  location = var.location
+  tags     = local.tags
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,47 +1,37 @@
-resource "azurerm_resource_group" "origin" {
-  name     = "${var.resource_group_name}-${local.suffix}"
-  location = var.location
-
-  tags = {
-    environment = var.environment_tag
-    component   = "origin-server"
-  }
-}
-
-resource "azurerm_virtual_network" "origin" {
-  name                = "vnet-origin-${local.suffix}"
+resource "azurerm_virtual_network" "main" {
+  name                = local.name.virtual_network
   address_space       = ["10.200.0.0/16"]
-  location            = azurerm_resource_group.origin.location
-  resource_group_name = azurerm_resource_group.origin.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
-  tags = azurerm_resource_group.origin.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_subnet" "origin" {
+resource "azurerm_subnet" "main" {
   #checkov:skip=CKV2_AZURE_31:Lab subnet - NSG associated at NIC level
-  name                 = "snet-origin"
-  resource_group_name  = azurerm_resource_group.origin.name
-  virtual_network_name = azurerm_virtual_network.origin.name
+  name                 = local.name.subnet
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.200.1.0/24"]
 }
 
-resource "azurerm_public_ip" "origin" {
-  name                = "pip-origin-${local.suffix}"
-  location            = azurerm_resource_group.origin.location
-  resource_group_name = azurerm_resource_group.origin.name
+resource "azurerm_public_ip" "main" {
+  name                = local.name.public_ip
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
   allocation_method   = "Static"
   sku                 = "Standard"
 
-  tags = azurerm_resource_group.origin.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_security_group" "origin" {
+resource "azurerm_network_security_group" "main" {
   #checkov:skip=CKV_AZURE_10:Lab NSG - SSH open for demo access
   #checkov:skip=CKV_AZURE_160:Lab NSG - HTTP port 80 required for traffic
   #checkov:skip=CKV_AZURE_220:Lab NSG - SSH open for demo access
-  name                = "nsg-origin-${local.suffix}"
-  location            = azurerm_resource_group.origin.location
-  resource_group_name = azurerm_resource_group.origin.name
+  name                = local.name.nsg
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
   security_rule {
     name                       = "AllowHTTP"
@@ -91,26 +81,26 @@ resource "azurerm_network_security_group" "origin" {
     destination_address_prefix = "*"
   }
 
-  tags = azurerm_resource_group.origin.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_interface" "origin" {
+resource "azurerm_network_interface" "main" {
   #checkov:skip=CKV_AZURE_119:Lab NIC - public IP required for demo access
-  name                = "nic-origin-${local.suffix}"
-  location            = azurerm_resource_group.origin.location
-  resource_group_name = azurerm_resource_group.origin.name
+  name                = local.name.network_interface
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.origin.id
+    subnet_id                     = azurerm_subnet.main.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = azurerm_public_ip.origin.id
+    public_ip_address_id          = azurerm_public_ip.main.id
   }
 
-  tags = azurerm_resource_group.origin.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_interface_security_group_association" "origin" {
-  network_interface_id      = azurerm_network_interface.origin.id
-  network_security_group_id = azurerm_network_security_group.origin.id
+resource "azurerm_network_interface_security_group_association" "main" {
+  network_interface_id      = azurerm_network_interface.main.id
+  network_security_group_id = azurerm_network_security_group.main.id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,69 +1,132 @@
+# ---------------------------------------------------------
+# Standard Outputs (present in every demo resource)
+# ---------------------------------------------------------
+
+output "deployer" {
+  description = "Resolved deployer identifier"
+  value       = local.deployer
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.main.name
+}
+
+output "resource_group_id" {
+  description = "Resource ID of the resource group"
+  value       = azurerm_resource_group.main.id
+}
+
+output "location" {
+  description = "Azure region"
+  value       = azurerm_resource_group.main.location
+}
+
 output "public_ip" {
-  description = "Public IP address of the origin server"
-  value       = azurerm_public_ip.origin.ip_address
+  description = "Public IP address of the VM"
+  value       = azurerm_public_ip.main.ip_address
+}
+
+output "private_ip" {
+  description = "Private IP address of the VM"
+  value       = azurerm_network_interface.main.private_ip_address
 }
 
 output "ssh_command" {
-  description = "SSH command to connect to the origin server"
-  value       = "ssh ${var.admin_username}@${azurerm_public_ip.origin.ip_address}"
+  description = "SSH command to connect to the VM"
+  value       = "ssh ${var.admin_username}@${azurerm_public_ip.main.ip_address}"
 }
+
+output "vm_name" {
+  description = "Name of the virtual machine"
+  value       = azurerm_linux_virtual_machine.main.name
+}
+
+output "vm_id" {
+  description = "Resource ID of the virtual machine"
+  value       = azurerm_linux_virtual_machine.main.id
+}
+
+output "nsg_name" {
+  description = "Name of the network security group"
+  value       = azurerm_network_security_group.main.name
+}
+
+output "nsg_id" {
+  description = "Resource ID of the network security group"
+  value       = azurerm_network_security_group.main.id
+}
+
+output "vnet_name" {
+  description = "Name of the virtual network"
+  value       = azurerm_virtual_network.main.name
+}
+
+output "subnet_id" {
+  description = "Resource ID of the subnet"
+  value       = azurerm_subnet.main.id
+}
+
+output "component" {
+  description = "Component name"
+  value       = local.component
+}
+
+output "environment" {
+  description = "Environment label"
+  value       = var.environment
+}
+
+# ---------------------------------------------------------
+# Component-Specific Outputs
+# ---------------------------------------------------------
 
 output "origin_url" {
   description = "Base HTTP URL of the origin server"
-  value       = "http://${azurerm_public_ip.origin.ip_address}"
+  value       = "http://${azurerm_public_ip.main.ip_address}"
 }
 
 output "health_check_url" {
   description = "Health check endpoint"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/health"
+  value       = "http://${azurerm_public_ip.main.ip_address}/health"
 }
 
 output "juice_shop_url" {
   description = "OWASP Juice Shop URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/juice-shop/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/juice-shop/"
 }
 
 output "dvwa_url" {
   description = "DVWA URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/dvwa/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/dvwa/"
 }
 
 output "vampi_url" {
   description = "VAmPI URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/vampi/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/vampi/"
 }
 
 output "httpbin_url" {
   description = "httpbin URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/httpbin/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/httpbin/"
 }
 
 output "whoami_url" {
   description = "whoami request diagnostics URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/whoami/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/whoami/"
 }
 
 output "dvga_url" {
   description = "DVGA GraphQL security URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/dvga/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/dvga/"
 }
 
 output "restaurant_url" {
   description = "RESTaurant API security URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}/restaurant/"
+  value       = "http://${azurerm_public_ip.main.ip_address}/restaurant/"
 }
 
 output "crapi_url" {
   description = "crAPI microservices security URL"
-  value       = "http://${azurerm_public_ip.origin.ip_address}:8888"
-}
-
-output "resource_group" {
-  description = "Resource group containing all origin server resources"
-  value       = azurerm_resource_group.origin.name
-}
-
-output "deployment_suffix" {
-  description = "Unique deployment suffix for this instance"
-  value       = local.suffix
+  value       = "http://${azurerm_public_ip.main.ip_address}:8888"
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,6 @@
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+provider "azuread" {}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,7 +1,15 @@
-subscription_id     = "00000000-0000-0000-0000-000000000000"
-resource_group_name = "rg-origin-server"
-location            = "eastus2"
-vm_size             = "Standard_D16s_v3"
-admin_username      = "azureuser"
-ssh_public_key_path = "~/.ssh/id_ed25519.pub"
-environment_tag     = "lab"
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — never commit real credentials.
+
+# --- Required ---
+subscription_id = "00000000-0000-0000-0000-000000000000"
+
+# --- Optional overrides (defaults shown) ---
+# deployer            = ""                       # auto-resolved from Azure AD
+# location            = "eastus2"
+# environment         = "lab"
+# vm_size             = "Standard_D16s_v3"
+# disk_size_gb        = 60
+# admin_username      = "azureuser"
+# ssh_public_key_path = "~/.ssh/id_ed25519.pub"
+# tags                = {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,12 +1,16 @@
+# ---------------------------------------------------------
+# General
+# ---------------------------------------------------------
+
 variable "subscription_id" {
   description = "Azure subscription ID"
   type        = string
 }
 
-variable "resource_group_name" {
-  description = "Name for the Azure resource group"
+variable "deployer" {
+  description = "Override for deployer identifier (auto-resolved from Azure AD if empty). Required for service principal or managed identity authentication."
   type        = string
-  default     = "rg-origin-server"
+  default     = ""
 }
 
 variable "location" {
@@ -15,8 +19,24 @@ variable "location" {
   default     = "eastus2"
 }
 
+variable "environment" {
+  description = "Environment label used in resource group naming and tags"
+  type        = string
+  default     = "lab"
+}
+
+variable "tags" {
+  description = "Additional tags merged with standard tags (component, environment, deployer, managed_by)"
+  type        = map(string)
+  default     = {}
+}
+
+# ---------------------------------------------------------
+# Compute
+# ---------------------------------------------------------
+
 variable "vm_size" {
-  description = "Azure VM size (Standard_D16s_v3 provides 16 vCPU, 64 GiB RAM for Docker workloads)"
+  description = "Azure VM size (Standard_D16s_v3: 16 vCPU, 64 GiB RAM for Docker workloads)"
   type        = string
   default     = "Standard_D16s_v3"
 }
@@ -33,8 +53,8 @@ variable "ssh_public_key_path" {
   default     = "~/.ssh/id_ed25519.pub"
 }
 
-variable "environment_tag" {
-  description = "Environment tag applied to all resources"
-  type        = string
-  default     = "lab"
+variable "disk_size_gb" {
+  description = "OS disk size in GB"
+  type        = number
+  default     = 60
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform/vm.tf
+++ b/terraform/vm.tf
@@ -1,9 +1,9 @@
-resource "azurerm_linux_virtual_machine" "origin" {
+resource "azurerm_linux_virtual_machine" "main" {
   #checkov:skip=CKV_AZURE_50:Lab VM - no extensions required
   #checkov:skip=CKV_AZURE_93:Lab VM - platform-managed encryption sufficient
-  name                = "vm-origin-${local.suffix}"
-  resource_group_name = azurerm_resource_group.origin.name
-  location            = azurerm_resource_group.origin.location
+  name                = local.name.virtual_machine
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
   size                = var.vm_size
 
   admin_username                  = var.admin_username
@@ -11,15 +11,15 @@ resource "azurerm_linux_virtual_machine" "origin" {
 
   admin_ssh_key {
     username   = var.admin_username
-    public_key = file(var.ssh_public_key_path)
+    public_key = file(pathexpand(var.ssh_public_key_path))
   }
 
-  network_interface_ids = [azurerm_network_interface.origin.id]
+  network_interface_ids = [azurerm_network_interface.main.id]
 
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
-    disk_size_gb         = 60
+    disk_size_gb         = var.disk_size_gb
   }
 
   source_image_reference {
@@ -29,7 +29,7 @@ resource "azurerm_linux_virtual_machine" "origin" {
     version   = "latest"
   }
 
-  custom_data = base64encode(file("${path.module}/cloud-init.yaml"))
+  custom_data = base64encode(templatefile("${path.module}/cloud-init.yaml", {}))
 
-  tags = azurerm_resource_group.origin.tags
+  tags = azurerm_resource_group.main.tags
 }


### PR DESCRIPTION
## Summary

- Split `main.tf` into `versions.tf`, `providers.tf`, `data.tf`, `locals.tf` (resource group stays in `main.tf`)
- Add `azuread` provider for automatic deployer name resolution (4-tier fallback)
- Remove `random` provider and `random_pet` suffix — replaced by deployer-based naming
- Switch cloud-init from `file()` to `templatefile()` for consistency (escaped `$` symbols)
- Adopt Azure CAF naming (`rg-origin-server-lab-rmordasiewicz`, `vm-origin-server-rmordasiewicz`)
- Rename all HCL resource labels from `origin` to `main`
- Standardize variables: add `deployer`, `environment`, `disk_size_gb`, `tags`; remove `resource_group_name`; rename `environment_tag` → `environment`
- Expand outputs from 14 to 25 (15 standard + 10 component-specific app URLs)
- Remove `deployment_suffix` output (no longer relevant without random_pet)
- Add `pathexpand()` for SSH key path
- Upgrade `component-manifest.json` to schema v2
- Add `.terraform-docs.yml` and auto-generated Terraform Reference in README
- Add `terraform_fmt`, `terraform_validate`, `terraform_docs` pre-commit hooks

Closes #106

## Test plan

- [x] `terraform fmt -check` passes
- [x] `terraform validate` passes
- [x] `terraform plan` succeeds with live Azure AD credentials
- [x] Deployer resolves to `rmordasiewicz`
- [x] Resource group: `rg-origin-server-lab-rmordasiewicz`
- [x] All 25 outputs present (15 standard + 10 app URLs)
- [x] Tags include all 4 standard keys
- [x] `component-manifest.json` validates as schema v2
- [x] All pre-commit hooks pass
- [x] cloud-init.yaml templatefile escaping works correctly