### PR TITLE
fix(cloud-init): create nginx cache dir before package install, replace dstat with dool

### DIFF
--- a/terraform/cloud-init.yaml
+++ b/terraform/cloud-init.yaml
@@ -2,6 +2,10 @@
 package_update: true
 package_upgrade: true
 
+bootcmd:
+  - mkdir -p /var/cache/nginx/juice_shop
+  - chown www-data:www-data /var/cache/nginx/juice_shop 2>/dev/null || true
+
 packages:
   - ca-certificates
   - curl
@@ -10,7 +14,7 @@ packages:
   - sysstat
   - htop
   - iotop
-  - dstat
+  - dool
   - iftop
 
 write_files:
@@ -1724,9 +1728,6 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   - systemctl enable docker
   - systemctl start docker
-  # nginx cache directory and systemd limits
-  - mkdir -p /var/cache/nginx/juice_shop
-  - chown www-data:www-data /var/cache/nginx/juice_shop
   - systemctl daemon-reload
   - ln -sf /etc/nginx/sites-available/origin-server /etc/nginx/sites-enabled/origin-server
   - rm -f /etc/nginx/sites-enabled/default


### PR DESCRIPTION
## Summary

Fixes two cloud-init failures discovered during QA deployment testing:

- Add `bootcmd` section to create `/var/cache/nginx/juice_shop` before `packages:` installs nginx — nginx post-install script starts the service and fails if the cache directory doesn't exist
- Replace `dstat` with `dool` — `dstat` was removed in Ubuntu 24.04

Closes #108

## Test plan

- [x] Deployed VM, cloud-init completed without nginx cache error
- [x] NGINX config test passes (`nginx -t`)
- [x] Health endpoint returns 200 with 9 applications
- [x] All 8 web app endpoints respond (200/302)
- [x] 41 Docker containers running
- [x] All 25 terraform outputs correct