### PR TITLE
docs: rewrite for terraform standardization, remove pricing, fix stale claims

### DIFF
--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -45,6 +45,10 @@ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://
 sudo apt update && sudo apt install terraform
 ```
 
+### Azure AD Permissions
+
+Your Azure AD account must have `User.Read` permissions. The deployer identifier (used in resource naming) is automatically derived from your Azure AD profile. For service principal or managed identity authentication, set the `deployer` Terraform variable explicitly.
+
 ### SSH Key Pair
 
 An SSH key pair for VM access:
@@ -53,19 +57,16 @@ An SSH key pair for VM access:
 ssh-keygen -t ed25519 -f ~/.ssh/origin-server-key -N ""
 ```
 
-## Resource Estimates
+## Azure Resources Created
 
-| Resource | SKU | Estimated Monthly Cost |
-|---|---|---|
-| Ubuntu 24.04 VM | Standard_D16s_v3 (16 vCPU, 64 GiB) | ~$486 USD |
-| Public IP | Standard, Static | ~$4 USD |
-| OS Disk | 60 GiB Premium SSD | ~$10 USD |
-| VNet + NSG | -- | No additional cost |
-| **Total** | | **~$500 USD/month** |
+| Resource | SKU |
+|---|---|
+| Ubuntu 24.04 VM | Standard_D16s_v3 (16 vCPU, 64 GiB) |
+| Public IP | Standard, Static |
+| OS Disk | 60 GiB Premium SSD |
+| VNet + NSG | Default |
 
-:::tip
-Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](../07-teardown/) for the procedure.
-:::
+See the [Azure pricing calculator](https://azure.microsoft.com/en-us/pricing/calculator/) for current costs. Use `terraform destroy` when the lab is not in use to stop charges. See [Teardown](../07-teardown/) for the procedure.
 
 :::note
 Standard_D16s_v3 (64 GiB RAM) is required for the 41-container deployment. Container memory allocation: 4 Juice Shop instances at 1 GiB each (4 GiB), 4 VAmPI at 512 MiB each (2 GiB), 4 DVWA-FPM + MariaDB (1.8 GiB), 4 httpbin at 256 MiB (1 GiB), 4 CSD Demo at 256 MiB (1 GiB), 4 whoami at 64 MiB (256 MiB), 4 DVGA at 256 MiB each (1 GiB), 4 RESTaurant + PostgreSQL (1.5 GiB), crAPI 7 microservices (2 GiB), plus nginx, OS, and buffer cache. Total container allocation is approximately 14.5 GiB (22.7% of 64 GiB).

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: "Complete Terraform IaC for Azure deployment: main.tf, variables.tf, network.tf, vm.tf, cloud-init.yaml, and outputs.tf with docker-compose for 41 containers across 9 applications. All configuration files are in the terraform/ directory."
+description: "Terraform IaC deployment following the Demo Resource Standard — 9 terraform files with Azure AD deployer auto-resolution, 25 outputs, and hardened cloud-init provisioning 41 Docker containers across 9 applications."
 sidebar:
   order: 3
 ---
@@ -16,14 +16,26 @@ cp terraform.tfvars.example terraform.tfvars
 
 ## Terraform Configuration
 
-### Provider and Variables
+### Terraform File Structure
 
-`main.tf` configures the Azure provider:
+The terraform directory contains 9 files following the Demo Resource Standard:
+
+- `versions.tf` — Terraform and provider version constraints (azurerm ~> 4.0, azuread ~> 3.0)
+- `providers.tf` — Azure RM and Azure AD provider configuration
+- `data.tf` — Azure AD data sources for deployer auto-resolution
+- `locals.tf` — Deployer resolution, Azure Cloud Adoption Framework resource naming, standard tags
+- `main.tf` — Resource group (named `rg-origin-server-{environment}-{deployer}`)
+- `variables.tf` — All input variables (1 required, 8 optional)
+- `network.tf` — VNet (10.200.0.0/16), subnet, public IP, NSG (ports 22/80/443/8888), NIC
+- `vm.tf` — Ubuntu 24.04 VM with cloud-init via templatefile()
+- `outputs.tf` — 25 outputs (15 standard + 10 component-specific application URLs)
+
+`main.tf` contains only the resource group:
 
 ```hcl file=./_data/main.tf
 ```
 
-`variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_D16s_v3` (16 vCPU, 64 GiB RAM) -- sized for 41 Docker containers under sustained load:
+`variables.tf` defines all configurable parameters. The `deployer` identifier is auto-resolved from your Azure AD account — you only need to set `subscription_id`. The `vm_size` default is `Standard_D16s_v3` (16 vCPU, 64 GiB RAM) sized for 41 Docker containers:
 
 ```hcl file=./_data/variables.tf
 ```
@@ -44,7 +56,7 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Cloud-Init Provisioning
 
-`cloud-init.yaml` is the production-optimized configuration verified under sustained torture testing at 128+ system load and 22K concurrent connections. It provisions:
+`cloud-init.yaml` provisions the VM with a hardened configuration. A shared helper library (`/usr/local/lib/cloud-init-helpers.sh`) provides retry logic on all network operations and progress logging to `/var/log/cloud-init-progress.log`. Active health-check polling replaces fixed-duration sleep for container readiness. It provisions:
 
 - **Kernel tuning**: TCP keepalive, TIME_WAIT reuse, 2M tw_buckets, 64K somaxconn
 - **nginx**: 8 upstream blocks with sticky sessions (ip_hash, cookie hash), keepalive pools (64--128), proxy cache for Juice Shop, error_log crit level
@@ -57,7 +69,7 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Outputs
 
-`outputs.tf` exposes the public IP, SSH command, per-application URLs, and resource group name:
+`outputs.tf` exposes 25 outputs following the Demo Resource Standard — 15 standard outputs shared by all demo resources (`deployer`, `public_ip`, `private_ip`, `ssh_command`, `resource_group_name`, `vm_name`, `nsg_name`, `vnet_name`, `subnet_id`, `component`, `environment`, `resource_group_id`, `vm_id`, `nsg_id`, `location`) plus 10 component-specific application URLs (`origin_url`, `health_check_url`, `juice_shop_url`, `dvwa_url`, `vampi_url`, `httpbin_url`, `whoami_url`, `dvga_url`, `restaurant_url`, `crapi_url`):
 
 ```hcl file=./_data/outputs.tf
 ```

--- a/docs/07-teardown.mdx
+++ b/docs/07-teardown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teardown
-description: "terraform destroy to remove all Azure resources (rg-origin-server), verify cleanup with az CLI, clean local state files, and remove associated F5 XC origin pool and HTTP load balancer"
+description: "terraform destroy to remove all Azure resources, verify cleanup with az CLI, clean local state files, and remove associated F5 XC origin pool and HTTP load balancer"
 sidebar:
   order: 7
 ---
@@ -24,11 +24,10 @@ Terraform will prompt for confirmation. Type `yes` to proceed.
 Confirm all resources have been removed:
 
 ```bash
-az group show --name rg-origin-server 2>&1 | grep -q "ResourceGroupNotFound" \
+az group show --name "$(terraform output -raw resource_group_name)" 2>&1 \
+  | grep -q "ResourceGroupNotFound" \
   && echo "Resource group deleted" \
   || echo "Resource group still exists"
-
-az resource list --resource-group rg-origin-server -o table 2>/dev/null
 ```
 
 ## Clean Up Local State
@@ -47,6 +46,3 @@ If you created F5 XC resources pointing to this origin server, remove them:
 2. Delete the origin pool
 3. Delete any WAF policies created for testing
 
-## Cost Reference
-
-While running, the origin server costs approximately $69 USD/month. After `terraform destroy`, all charges stop. There are no residual costs from deleted resources.


### PR DESCRIPTION
## Summary

Rewrites documentation prose to match standardized terraform and hardened cloud-init.

- **03-deploy**: Replace stale "main.tf configures provider" with 9-file structure overview; document deployer auto-resolution; list all 25 outputs (15 standard + 10 app URLs); update cloud-init description with helper library, retry logic, health-check polling
- **07-teardown**: Replace hardcoded `rg-origin-server` with `terraform output -raw resource_group_name`; remove cost reference ($69 was wrong — contradicts $500 in prerequisites)
- **02-prerequisites**: Remove pricing table; add Azure AD permissions section for deployer resolution; add Azure pricing calculator link

Closes #122

## Test plan
- [x] No hardcoded resource names remaining
- [x] No pricing information remaining
- [x] 25 outputs documented
- [x] Cloud-init helper library and health-check polling documented