### PR TITLE
docs: add component name and dependency context to deployment custom set description

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -2,7 +2,7 @@
   "customSets": [
     {
       "label": "Deployment",
-      "description": "Terraform IaC deployment with prerequisites and teardown",
+      "description": "Origin Server Terraform deployment — requires only subscription_id, outputs public_ip for CDN simulator and F5 XC origin pool",
       "paths": ["02-prerequisites*", "03-deploy*", "07-teardown*"]
     },
     {


### PR DESCRIPTION
## Summary

- Update the Deployment customSet description in `docs/llms-config.json` to include the component name ("Origin Server"), required input (`subscription_id`), and output (`public_ip`) that feeds downstream components
- The starlight-llms-txt plugin uses this description as the SYSTEM tag header in deployment.txt, so AI assistants need it to distinguish between component deployment guides

Closes #126

## Test plan

- [ ] CI checks pass (lint, spelling, editorconfig)
- [ ] Verify `docs/llms-config.json` is valid JSON
- [ ] Confirm the description reads: "Origin Server Terraform deployment — requires only subscription_id, outputs public_ip for CDN simulator and F5 XC origin pool"