### PR TITLE
fix: restamp stale translation sourceHash (unblocks Translation freshness)

### DIFF
--- a/docs/ar/03-deploy.mdx
+++ b/docs/ar/03-deploy.mdx
@@ -7,7 +7,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -24,7 +24,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/de/03-deploy.mdx
+++ b/docs/de/03-deploy.mdx
@@ -8,7 +8,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -25,7 +25,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/es/03-deploy.mdx
+++ b/docs/es/03-deploy.mdx
@@ -8,7 +8,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -25,7 +25,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/fr/03-deploy.mdx
+++ b/docs/fr/03-deploy.mdx
@@ -8,7 +8,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -25,7 +25,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/hi/03-deploy.mdx
+++ b/docs/hi/03-deploy.mdx
@@ -7,7 +7,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -24,7 +24,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/it/03-deploy.mdx
+++ b/docs/it/03-deploy.mdx
@@ -7,7 +7,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -25,7 +25,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/ja/03-deploy.mdx
+++ b/docs/ja/03-deploy.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -23,7 +23,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/ko/03-deploy.mdx
+++ b/docs/ko/03-deploy.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -23,7 +23,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/pt-br/03-deploy.mdx
+++ b/docs/pt-br/03-deploy.mdx
@@ -7,7 +7,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -25,7 +25,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/th/03-deploy.mdx
+++ b/docs/th/03-deploy.mdx
@@ -8,7 +8,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -24,7 +24,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/zh-cn/03-deploy.mdx
+++ b/docs/zh-cn/03-deploy.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -21,7 +21,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 

--- a/docs/zh-tw/03-deploy.mdx
+++ b/docs/zh-tw/03-deploy.mdx
@@ -6,7 +6,7 @@ description: >-
 sidebar:
   order: 3
 i18n:
-  sourceHash: 46d2d343bc70
+  sourceHash: f63e2a3c34e2
   translator: machine
 ---
 

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -21,7 +21,7 @@ hero:
       icon: rocket
       variant: minimal
 i18n:
-  sourceHash: 659c78136774
+  sourceHash: 49d137573936
   translator: machine
 ---
 


### PR DESCRIPTION
## Problem

`audit / Translation freshness` fails on 24 machine-translated locale files, blocking governance sync PR #327. Root cause: the org-rename sweep (`f5xc-salesdemos` → `f5-sales-demo`) updated en+locale content but did not restamp `i18n.sourceHash`.

Verified content-current: the only en change since each stored hash is the org rename, already applied in the locale files (guard confirmed org-rename-only for every file; 0 needing re-translation).

## Fix

Restamp `i18n.sourceHash` to `sha256(en)[:12]` in the 24 affected files. One hash line per file; no prose edits.

## Acceptance criteria
- [ ] `audit / Translation freshness` passes.
- [ ] Only `sourceHash` values change.

Unblocks governance sync PR #327.

Closes #328