### PR TITLE
fix(ci): drop unused write scopes from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,14 @@ on:
       - ".github/workflows/release.yml"
   workflow_dispatch:
 
+# Read-only: none of these scopes had a GITHUB_TOKEN consumer. semantic-release
+# performs every write — creating the release and uploading manifest.json via
+# @semantic-release/github, and commenting on linked issues and PRs — while
+# authenticated as RELEASE_TOKEN, not the workflow token. @semantic-release/git is
+# installed but absent from the plugins array in release.config.js, so nothing
+# pushes to the repository either.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release


### PR DESCRIPTION
## Problem

The scheduled Workflow Security Audit (docs-control#775) fails on this repo with three
high-confidence findings — one per workflow-level write scope in `release.yml`:

```
error[excessive-permissions] @ .github/workflows/release.yml:26:3  contents: write
error[excessive-permissions] @ .github/workflows/release.yml:27:3  issues: write
error[excessive-permissions] @ .github/workflows/release.yml:28:3  pull-requests: write
```

## Change

All three dropped; the workflow is now `contents: read`.

The reason this is safe is that none of the three had a `GITHUB_TOKEN` consumer. I checked
each write the release actually performs:

| Write | Performed by | Authenticated as |
|---|---|---|
| Create GitHub release, upload `manifest.json` | `@semantic-release/github` | `RELEASE_TOKEN` |
| Comment on linked issues / PRs | `@semantic-release/github` | `RELEASE_TOKEN` |
| Push a commit or tag | *nothing* | — |

`npx semantic-release` runs with `GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}`, so the
workflow token is not what authorises any of it. And although `@semantic-release/git` is in
the `npm install` list, it is **not** in the `plugins` array in `release.config.js`, so no
commit or tag is pushed at all — which is why `contents: write` was unnecessary rather than
merely over-broad.

The two jobs (`validate`, `release`) need only `contents: read` for `actions/checkout`.

## Verification

Run with zizmor **1.25.2**, the version super-linter pins.

| | exit | findings |
|---|---|---|
| before | 14 | 3 high |
| after | **0** | **none, any severity** |

`actionlint` clean.

This is the release path, so the next release should be confirmed by artifact — that the
GitHub release appears with `manifest.json` attached — rather than by a green check alone.
The argument above says `RELEASE_TOKEN` carries it, but that deserves a real observation.

Closes #401
