### PR TITLE
fix(ci): restore contents write on the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,10 @@ on:
       - ".github/workflows/release.yml"
   workflow_dispatch:
 
-# Read-only: none of these scopes had a GITHUB_TOKEN consumer. semantic-release
-# performs every write — creating the release and uploading manifest.json via
-# @semantic-release/github, and commenting on linked issues and PRs — while
-# authenticated as RELEASE_TOKEN, not the workflow token. @semantic-release/git is
-# installed but absent from the plugins array in release.config.js, so nothing
-# pushes to the repository either.
+# Read-only by default; the release job raises contents to write (see below).
+# `issues: write` and `pull-requests: write` stay dropped: @semantic-release/github
+# creates the release, uploads manifest.json and comments on linked issues and PRs
+# while authenticated as RELEASE_TOKEN, not the workflow token.
 permissions:
   contents: read
 
@@ -50,6 +48,14 @@ jobs:
     name: Semantic Release
     needs: validate
     runs-on: ubuntu-latest
+    # semantic-release's verifyConditions runs `git push --dry-run` before doing
+    # anything, and it pushes with the credential actions/checkout persisted — the
+    # workflow GITHUB_TOKEN, since no `token:` or `persist-credentials: false` is set
+    # here. That check runs whether or not @semantic-release/git is configured, so
+    # this scope is required even though no plugin pushes. Dropping it in #404 broke
+    # every release run with EGITNOPERMISSION (#409).
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Regression from #404 — my error, and how it happened

`Release` has failed on **every run since #404 merged** (13:53:59Z), having succeeded on
every run for the previous week.

```
[semantic-release] ✘ git push --dry-run ... denied to github-actions[bot]  → 403
[semantic-release] ✘ EGITNOPERMISSION Cannot push to the Git repository.
```

#404 dropped `contents: write` on the reasoning that semantic-release does every write as
`RELEASE_TOKEN`, and that `@semantic-release/git` is absent from `release.config.js` so
nothing pushes. I checked the plugins array and the `GITHUB_TOKEN:` env value and concluded
the scope was unused.

**Both facts were right and the conclusion was still wrong**, because they answer only one
of two separate questions:

| Question | Answer here |
|---|---|
| Which token authenticates the **GitHub API** calls? | `RELEASE_TOKEN` (via the `GITHUB_TOKEN:` env) |
| Which credential does **git** push with? | The workflow `GITHUB_TOKEN`, persisted by `actions/checkout` |

`actions/checkout@v7` is used with no `token:` and no `persist-credentials: false`, so it
installs the workflow token as the git credential helper — hence `github-actions[bot]` in
the error. And semantic-release's `verifyConditions` runs `git push --dry-run`
**regardless of which plugins are configured**. So the scope had a genuine consumer that was
not a plugin, which is exactly why inspecting `release.config.js` could not rule it out.

## Change

`contents: write` restored on the `release` job only, with the reason recorded inline.

Deliberately **not** reverting the rest of #404:

- Workflow default stays `contents: read`.
- `issues: write` and `pull-requests: write` stay dropped. Evidence they were never needed:
  in the same failing log, `@semantic-release/github`'s issue-creation call failed on
  *label name validation*, not a 403 — so it authenticated fine without them.

## Verification

| Check | Result |
|---|---|
| `uvx zizmor@1.25.2 .github/workflows/` | exit **0**, no findings at any severity |
| `actionlint` | exit **0** |

The job-scoped grant is not itself a zizmor finding, so this does not undo the audit fix.

**This PR going green proves nothing about the actual bug.** The thing to confirm is a real
`Release` run on `main` completing — that is the acceptance criterion in #409, and I will
check it rather than infer it from a green check. That failure to verify by effect is what
let #404 ship broken in the first place.

Closes #409
