### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "worktree": {
     "baseRef": "fresh"
   },
+  "permissions": {
+    "deny": ["Skill(code-review:code-review)", "Skill(pr-review-toolkit:review-pr)"]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,19 +18,37 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.
-- The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. See CONTRIBUTING.md.
 
-## Second-opinion review (when available)
+## Two review layers — never substitute one for the other
+
+Reviewing a **spec or plan** and reviewing a **pull-request diff** are different jobs, done by different tools, with different authority. Pick by what you are reviewing, not by the word "review".
+
+| Layer | What it reviews | When | Tool | Authority |
+| ----- | --------------- | ---- | ---- | --------- |
+| **Local, pre-PR** | A spec, an implementation plan, or your own unpushed branch | Before a human reviews the document; before a push that opens or updates a PR; after each round of fixes | `codex:verified-code-review` | Advisory. Never a merge gate. |
+| **CI** | The pull-request diff | Automatically, on every PR | Self-hosted `review / claude-review` workflow | **Required and merge-gating.** |
+
+### Local, pre-PR (Codex second opinion)
 
 When the `codex` plugin provides the `verified-code-review` skill, use it as a second-opinion reviewer at three points. When the skill is not installed, skip it and continue — this is an additive local layer, never a merge gate.
 
-- Before asking a human to review a written spec or an implementation plan.
-- Before pushing a branch that will open or update a pull request.
+- Before asking a human to review a written spec or an implementation plan. **This is the layer's primary use.** Review the document itself — `review-doc --kind spec` or `review-doc --kind plan` — not a diff.
+- Before pushing a branch that will open or update a pull request (`adversarial-review`, against the base ref or uncommitted work).
 - After each round of fixes, until no confirmed critical or high finding remains.
+
+**Never review a spec, a plan, or a local branch with a PR-diff reviewer.** Do not invoke `code-review:code-review`, `code-review-f5:code-review`, `pr-review-toolkit:review-pr`, `/review`, or `/security-review` as your local review step.
+
+- They review a pull-request diff, which is the CI layer's job — and a spec has no diff to review.
+- Enforced, not just documented: `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`, and `code-review-f5:code-review` is marked `disable-model-invocation` in the vendored plugin. A wrong choice fails loudly instead of quietly producing the wrong kind of review.
+- `/review` and `/security-review` are built-in commands that no rule can deny. Not selecting them for local spec, plan, or branch review is on you.
 
 Treat every second-opinion finding as external review feedback under `superpowers:receiving-code-review`: verify each claim against this codebase before acting on it, and push back with technical reasoning when it is wrong. Fix only confirmed findings, each with a test that fails before the fix and passes after.
 
-Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none. The required `review / claude-review` check remains the merge gate, and this local layer never replaces it.
+Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none.
+
+### CI (the merge gate)
+
+The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. The local layer never replaces it. See CONTRIBUTING.md.
 
 ## Worktrees
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,15 @@ git checkout -b feature/42-add-rate-limiting
 
 ## Automated code review
 
+Review happens in two layers. They are not interchangeable, and neither substitutes for the other:
+
+| Layer | What it reviews | Authority |
+| ----- | --------------- | --------- |
+| **Local, pre-PR** | A spec, an implementation plan, or an unpushed branch | Advisory |
+| **CI** | The pull-request diff | **Required and merge-gating** |
+
+### CI review (the gate)
+
 Every downstream pull request is reviewed by a **Claude Code reviewer** running on a self-hosted
 runner. It is a **required status check** (`review / claude-review`) — auto-merge will not merge
 until it passes.
@@ -117,6 +126,29 @@ until it passes.
   and the linked-issue check — this is for machine-generated PRs only. The authoritative prefix
   list lives in `require-linked-issue.yml` and `code-review.yml`; never adopt such a prefix for
   human or agent work.
+
+### Local pre-PR review (advisory second opinion)
+
+A second review layer runs on your own machine **before the pull request exists**. It catches
+problems while they are still cheap to fix — in a spec or a plan, before any code is written.
+
+- **Advisory, never a gate.** It emits no verdict and posts no commit status, so it cannot block a
+  merge or deadlock a required check. When the tooling is absent it is skipped and work continues.
+- **Where it runs.** At the spec and plan review points, before a push that opens or updates a pull
+  request, and after each round of fixes. Reviewing a written spec or implementation plan is its
+  primary use — a document, not a diff.
+- **Verification is mandatory.** A finding counts only once it has been confirmed against the
+  codebase: for code, with a test that fails today; for a document, with a quotation. An AI reviewer
+  misattributes findings to files that do not contain them, and a hallucinated blocking finding can
+  never be fixed — treating it as blocking would stop the loop from ever terminating.
+- **Bounded.** Three iterations maximum, with no-progress detection when two consecutive rounds
+  produce the same blocking set. On either, the outstanding findings go to a human.
+- **Do not reach for a PR-diff reviewer instead.** Reviewing a spec, a plan, or a local branch with
+  a pull-request review tool is the wrong layer — a spec has no diff to review. `CLAUDE.md` names
+  the tool to use, the tools not to use, and the deny rules that enforce it.
+
+The two layers are complementary: the local layer catches issues before the pull request exists and
+costs nothing when it is wrong, while CI remains the gate that decides whether a change merges.
 
 ## Branch Protection Rules
 


### PR DESCRIPTION
Closes #415

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- CONTRIBUTING.md
- CLAUDE.md
- .claude/settings.json