### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -222,9 +222,10 @@ repos:
         types: [text]
         # codespell's own `skip` list only applies during its directory
         # traversal; when pre-commit passes explicit file paths it is bypassed.
-        # Filter translation docs and source catalogs here so their
-        # foreign-language words never reach codespell. See issues #579 and #934.
-        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations|research/benchmarks/uat-matrix/corpora/i18n\.yaml$)
+        # Filter generated artifacts, translation docs, and source catalogs
+        # here so generated identifiers and foreign-language words never reach
+        # codespell. See issues #579, #934, and #1234.
+        exclude: ^(dist/|build/|release/|vendor/|docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations|research/benchmarks/uat-matrix/corpora/i18n\.yaml$)
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json

--- a/README.md
+++ b/README.md
@@ -1,29 +1,16 @@
-# Origin Server
+# CDN Simulator
 
-🌐 English |
-[日本語](https://f5-sales-demo.github.io/origin-server/ja/) |
-[한국어](https://f5-sales-demo.github.io/origin-server/ko/) |
-[简体中文](https://f5-sales-demo.github.io/origin-server/zh-cn/) |
-[繁體中文](https://f5-sales-demo.github.io/origin-server/zh-tw/) |
-[Español](https://f5-sales-demo.github.io/origin-server/es/) |
-[Português](https://f5-sales-demo.github.io/origin-server/pt-br/) |
-[Français](https://f5-sales-demo.github.io/origin-server/fr/) |
-[Deutsch](https://f5-sales-demo.github.io/origin-server/de/) |
-[Italiano](https://f5-sales-demo.github.io/origin-server/it/) |
-[العربية](https://f5-sales-demo.github.io/origin-server/ar/) |
-[हिन्दी](https://f5-sales-demo.github.io/origin-server/hi/) |
-[ไทย](https://f5-sales-demo.github.io/origin-server/th/)
+__LANGUAGE_NAV__
 
-[![GitHub Pages Deploy](https://github.com/f5-sales-demo/origin-server/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5-sales-demo/origin-server/actions/workflows/github-pages-deploy.yml)
-[![Repository Settings](https://github.com/f5-sales-demo/origin-server/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/origin-server/actions/workflows/enforce-repo-settings.yml)
-[![Release](https://github.com/f5-sales-demo/origin-server/actions/workflows/release.yml/badge.svg)](https://github.com/f5-sales-demo/origin-server/actions/workflows/release.yml)
-[![License](https://img.shields.io/github/license/f5-sales-demo/origin-server)](LICENSE)
+[![GitHub Pages Deploy](https://github.com/f5-sales-demo/cdn-simulator/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5-sales-demo/cdn-simulator/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5-sales-demo/cdn-simulator/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/cdn-simulator/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5-sales-demo/cdn-simulator)](LICENSE)
 
-Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments
+NGINX-based CDN edge node simulator on Azure for multi-vendor lab environments
 
 ## Documentation
 
-Full documentation is available at **[https://f5-sales-demo.github.io/origin-server/](https://f5-sales-demo.github.io/origin-server/)**.
+Full documentation is available at **[https://f5-sales-demo.github.io/cdn-simulator/](https://f5-sales-demo.github.io/cdn-simulator/)**.
 
 ## Contributing
 


### PR DESCRIPTION
Closes #518

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .pre-commit-config.yaml
- README.md