### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ concurrency:
 jobs:
   validate:
     name: Validate Manifest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, origin-server]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
       - run: node scripts/validate-manifest.js
@@ -47,7 +47,7 @@ jobs:
   release:
     name: Semantic Release
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, origin-server]
     # semantic-release's verifyConditions runs `git push --dry-run` before doing
     # anything, and it pushes with the credential actions/checkout persisted — the
     # workflow GITHUB_TOKEN, since no `token:` or `persist-credentials: false` is set
@@ -57,11 +57,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   validate:
     name: Validate Manifest
-    runs-on: [self-hosted, Linux, X64, origin-server]
+    runs-on: [self-hosted, Linux, X64, origin-server, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -47,7 +47,7 @@ jobs:
   release:
     name: Semantic Release
     needs: validate
-    runs-on: [self-hosted, Linux, X64, origin-server]
+    runs-on: [self-hosted, Linux, X64, origin-server, ubuntu-24.04]
     # semantic-release's verifyConditions runs `git push --dry-run` before doing
     # anything, and it pushes with the credential actions/checkout persisted — the
     # workflow GITHUB_TOKEN, since no `token:` or `persist-credentials: false` is set

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: [self-hosted, Linux, X64, origin-server, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
@@ -60,6 +62,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -76,6 +79,9 @@ jobs:
           @semantic-release/github
 
       - name: Run semantic-release
-        run: npx semantic-release
+        run: |
+          gh auth setup-git
+          npx semantic-release
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null


### PR DESCRIPTION
Closes #570

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.