### PR TITLE
docs: verify linked-issue check

### DIFF
--- a/docs/en/04-applications.mdx
+++ b/docs/en/04-applications.mdx
@@ -428,3 +428,5 @@ Port 8888 -> crapi-web (React SPA + nginx)
 | Basic connectivity testing | httpbin | -- |
 | Request diagnostics | whoami | httpbin |
 | Header injection verification | whoami | -- |
+
+<!-- Linked-issue verification marker: #640. -->


### PR DESCRIPTION
Closes #640\n\nAdds one inert documentation marker to verify the canonical linked-issue PR check.