### PR TITLE
docs: restore Pages build

### DIFF
--- a/docs/en/04-applications.mdx
+++ b/docs/en/04-applications.mdx
@@ -148,7 +148,7 @@ VAmPI is purpose-built for testing the OWASP API Security Top 10. It provides a 
 # Register a new user
 curl -X POST "http://<PUBLIC_IP>/vampi/users/v1/register" \
   -H "Content-Type: application/json" \
-  -d '{"username":"test","password":"test123","email":"test@test.com"}'
+  -d '{"username":"test","password":"test123","email":"admin@example.com"}'
 
 # Login
 curl -X POST "http://<PUBLIC_IP>/vampi/users/v1/login" \
@@ -428,5 +428,3 @@ Port 8888 -> crapi-web (React SPA + nginx)
 | Basic connectivity testing | httpbin | -- |
 | Request diagnostics | whoami | httpbin |
 | Header injection verification | whoami | -- |
-
-<!-- Linked-issue verification marker: #640. -->


### PR DESCRIPTION
## Summary

- remove the obsolete linked-issue verification marker that blocks the production MDX build
- remove the resulting terminal blank line
- replace the flagged email example with a documentation-reserved address

## Validation

- `bash scripts/lint-mdx-prose.sh <changed-file>`
- `bash scripts/check-pii.sh --scope changed --mode enforce`
- production-equivalent build with `ghcr.io/f5-sales-demo/docs-builder@sha256:ba96cff87c091d2f39f6ec9cf94e7036fb2cad58738bb238ff22a71e6d467e92` and `docker run --pull=never`
- build output verified non-empty

No AGY or Antigravity review was run.

Closes #657