### PR TITLE
ci: use immutable Node toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "lts/*"
+          node-version: "24.19.0"
       - run: node scripts/validate-manifest.js
 
   release:
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "lts/*"
+          node-version: "24.19.0"
 
       - name: Install locked release dependencies
         run: npm ci --ignore-scripts


### PR DESCRIPTION
## Summary

- pin both release workflow jobs to Node 24.19.0
- retain the current lockfile-backed `npm ci --ignore-scripts` release dependency install
- remove the remaining floating `lts/*` selectors

## Verification

- `actionlint .github/workflows/release.yml`
- `npm ci --ignore-scripts` (0 vulnerabilities)
- `node scripts/validate-manifest.js`
- `bash tests/test-check-repo-hygiene.sh`
- `bash tests/test-check-pii.sh`
- exact assertions: two Node 24.19.0 selectors and zero `lts/*` selectors
- AGY reviewer and verifier: approve, zero findings

Closes #633